### PR TITLE
fix: TUI rendering corruption + human player support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,44 +10,42 @@ cargo build --release                    # Release build (binary: target/release
 cargo test                               # All tests
 cargo test game::rules                   # Tests in a specific module
 cargo test test_name                     # Single test by name
-cargo run                                # Launch TUI (title screen → menus → game)
-cargo run -- --headless --demo           # Headless text-mode demo (no API keys)
-cargo run -- --demo --seed 42            # Headless with reproducible board
-RUST_LOG=debug cargo run -- --demo       # Verbose logging
+cargo run                                # Launch TUI (title screen -> menus -> game)
 ```
 
-The binary boots into a TUI by default (title screen → main menu → game setup). Use `--headless` (or any legacy flag like `--demo`, `--replay`, `--resume`) for text-mode output. LLM mode requires provider API keys as env vars: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`.
+The binary boots into a TUI (title screen -> main menu -> game setup). LLM mode requires provider API keys as env vars: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`.
 
 ## Architecture
 
 **settl** is a terminal Catan game (~9k lines Rust) where LLMs play via tool/function calling. The codebase has five modules:
 
-### `game/` — Core engine (stateless rules + stateful orchestrator)
-- **`board.rs`** — Hex grid using axial coordinates `(q, r)`. Vertices and edges are expressed as `(HexCoord, Direction)` pairs. Only canonical edge directions (NE, E, SE) are stored; opposites resolve to the neighbor's canonical form.
-- **`state.rs`** — `GameState` holds the full mutable game: board, per-player resources/cards (`PlayerState`), buildings, roads, robber position, dev card deck, longest road/largest army tracking. `GamePhase` enum drives the state machine (Setup → Playing → Discarding → PlacingRobber → Stealing → GameOver).
-- **`rules.rs`** — Pure validation functions. Given a `GameState`, returns legal moves. Enforces distance rule, connectivity, resource costs, dev card logic, longest road calculation. Largest file (~1760 lines).
-- **`orchestrator.rs`** — Drives the game loop. Calls `Player` trait methods at decision points, applies actions through the rules engine, records events, sends UI updates via `mpsc` channel. Runs the setup snake-draft and main turn loop.
-- **`dice.rs`** — Dice rolling and resource distribution per hex/number.
+### `game/` -- Core engine (stateless rules + stateful orchestrator)
+- **`board.rs`** -- Hex grid using axial coordinates `(q, r)`. Vertices and edges are expressed as `(HexCoord, Direction)` pairs. Only canonical edge directions (NE, E, SE) are stored; opposites resolve to the neighbor's canonical form.
+- **`state.rs`** -- `GameState` holds the full mutable game: board, per-player resources/cards (`PlayerState`), buildings, roads, robber position, dev card deck, longest road/largest army tracking. `GamePhase` enum drives the state machine (Setup -> Playing -> Discarding -> PlacingRobber -> Stealing -> GameOver).
+- **`rules.rs`** -- Pure validation functions. Given a `GameState`, returns legal moves. Enforces distance rule, connectivity, resource costs, dev card logic, longest road calculation. Largest file (~1760 lines).
+- **`orchestrator.rs`** -- Drives the game loop. Calls `Player` trait methods at decision points, applies actions through the rules engine, records events, sends UI updates via `mpsc` channel. Runs the setup snake-draft and main turn loop.
+- **`dice.rs`** -- Dice rolling and resource distribution per hex/number.
 
-### `player/` — Player abstraction (async trait)
-- **`mod.rs`** — `Player` trait with async methods: `choose_action`, `choose_settlement`, `choose_road`, `choose_resource`, `respond_to_trade`, etc. Each returns `(choice, reasoning_string)`.
-- **`llm.rs`** — `LlmPlayer` uses the `genai` crate for multi-provider LLM support. Defines JSON-schema tools (`choose_index`, `choose_resource`, `discard_tool`, `propose_trade_tool`) for structured responses. Retries up to 2x on parse failure, falls back to random.
-- **`random.rs`** — `RandomPlayer` for testing and `--demo` mode.
-- **`human.rs`** — `HumanPlayer` for terminal input.
-- **`prompt.rs`** — Serializes board/state into text for LLM context.
-- **`personality.rs`** — Loads TOML personality configs (aggression/cooperation scores, style text, catchphrases) and injects into system prompts. Built-in personalities: Default Strategist, Aggressive Trader, Grudge Holder, Cautious Builder, Chaos Agent. Custom ones go in `personalities/*.toml`.
+### `player/` -- Player abstraction (async trait)
+- **`mod.rs`** -- `Player` trait with async methods: `choose_action`, `choose_settlement`, `choose_road`, `choose_resource`, `respond_to_trade`, etc. Each returns `(choice, reasoning_string)`.
+- **`llm.rs`** -- `LlmPlayer` uses the `genai` crate for multi-provider LLM support. Defines JSON-schema tools (`choose_index`, `choose_resource`, `discard_tool`, `propose_trade_tool`) for structured responses. Retries up to 2x on parse failure, falls back to random.
+- **`random.rs`** -- `RandomPlayer` for testing and `--demo` mode.
+- **`human.rs`** -- `HumanPlayer` for raw stdin input (non-TUI).
+- **`tui_human.rs`** -- `TuiHumanPlayer` for TUI mode; communicates with the UI via channels to show a selection overlay.
+- **`prompt.rs`** -- Serializes board/state into text for LLM context.
+- **`personality.rs`** -- Loads TOML personality configs (aggression/cooperation scores, style text, catchphrases) and injects into system prompts. Built-in personalities: Default Strategist, Aggressive Trader, Grudge Holder, Cautious Builder, Chaos Agent. Custom ones go in `personalities/*.toml`.
 
-### `trading/` — Trade negotiation
-- **`negotiation.rs`** — Multi-round trade protocol: propose → respond (accept/reject/counter) → execute.
-- **`offers.rs`** — Trade validation (both sides have resources, no self-trades) and `trade_value_heuristic()` scoring.
+### `trading/` -- Trade negotiation
+- **`negotiation.rs`** -- Multi-round trade protocol: propose -> respond (accept/reject/counter) -> execute.
+- **`offers.rs`** -- Trade validation (both sides have resources, no self-trades) and `trade_value_heuristic()` scoring.
 
-### `replay/` — Event sourcing
-- **`event.rs`** — `GameEvent` enum covering all game actions (setup, turns, building, trading, dev cards, robber).
-- **`recorder.rs`** — `GameReplay` with `ReplayFrame`s (event + VP snapshot + resource totals).
-- **`save.rs`** — Save/resume serialization.
+### `replay/` -- Event sourcing
+- **`event.rs`** -- `GameEvent` enum covering all game actions (setup, turns, building, trading, dev cards, robber).
+- **`recorder.rs`** -- `GameReplay` with `ReplayFrame`s (event + VP snapshot + resource totals).
+- **`save.rs`** -- Save/resume serialization.
 - Output files: `game_log.jsonl` (one event/line), `game_replay.json` (full replay), `game_save.json` (resumable state).
 
-### `ui/` — TUI (ratatui + crossterm)
+### `ui/` -- TUI (ratatui + crossterm)
 - Async game engine runs in a background tokio task; TUI runs on the main thread.
 - Communication via `mpsc::unbounded_channel` sending `StateUpdate` events.
 - `board_view.rs` renders the hex board, `chat_panel.rs` shows AI reasoning, `resource_bar.rs` shows player stats, `game_log.rs` is scrollable event history.
@@ -59,6 +57,24 @@ The binary boots into a TUI by default (title screen → main menu → game setu
 - **Event sourcing**: All actions become immutable `GameEvent`s, enabling perfect replays and save/resume.
 - **Game logic is UI-independent**: The engine runs headless; TUI is an optional observer via channel.
 - **Personality = system prompt injection**: No hardcoded behavioral branches; personality is entirely expressed as LLM prompt text.
+
+## Coding Style
+
+- Keep code `cargo fmt`-clean and `cargo clippy`-clean.
+- Run `cargo fmt`, `cargo clippy`, and `cargo test` before finishing any task.
+- **Never use emdashes** in documentation or comments.
+- Rust naming: `snake_case` for modules/functions, `CamelCase` for types, `SCREAMING_SNAKE_CASE` for constants.
+- Add comments where they aid understanding, but remove obvious ones (section headers restating the next line, comments that just name what the code does).
+
+## Testing
+
+- Unit tests go in-module (`#[cfg(test)]`); integration tests in `tests/`.
+- Tests must be deterministic. Use seeded RNG where randomness is needed.
+
+## Commits & PRs
+
+- Branch names: `feature/...`, `fix/...`, `docs/...`, `refactor/...`.
+- Commit messages: use conventional prefixes (`feat:`, `fix:`, `docs:`, `refactor:`).
 
 ## Catan Resource Costs
 

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -98,18 +98,14 @@ impl GameOrchestrator {
     /// Wrap an async player decision in a timeout. Returns the fallback on timeout.
     async fn with_timeout<T>(
         &self,
-        player_id: PlayerId,
-        what: &str,
+        _player_id: PlayerId,
+        _what: &str,
         future: impl std::future::Future<Output = T>,
         fallback: T,
     ) -> T {
         match tokio::time::timeout(PLAYER_DECISION_TIMEOUT, future).await {
             Ok(result) => result,
             Err(_) => {
-                eprintln!(
-                    "  Player {} ({}) timed out on {} — using fallback",
-                    player_id, self.player_names[player_id], what
-                );
                 fallback
             }
         }
@@ -124,12 +120,10 @@ impl GameOrchestrator {
 
     /// Run the full game and return the winner's PlayerId.
     pub async fn run(&mut self) -> Result<PlayerId, OrchestratorError> {
-        println!("=== CATAN — Terminal Edition ===\n");
 
         // Skip setup if the game is already past the setup phase (e.g. resumed).
         if matches!(self.state.phase, GamePhase::Setup { .. }) {
             self.run_setup().await?;
-            println!("\n=== Setup complete! Starting main game. ===\n");
 
             // Transition to Playing phase.
             self.state.phase = GamePhase::Playing {
@@ -137,7 +131,6 @@ impl GameOrchestrator {
                 has_rolled: false,
             };
         } else {
-            println!("Resuming game at turn {}...\n", self.state.turn_number + 1);
         }
 
         // Phase 2: Main game loop.
@@ -160,7 +153,6 @@ impl GameOrchestrator {
                     "Player {} ({}) wins with {} VP!",
                     winner, self.player_names[winner], vp
                 );
-                println!("\n{}", msg);
                 self.replay.winner = Some(winner);
                 self.record_event(GameEvent::GameWon {
                     player: winner,
@@ -184,10 +176,6 @@ impl GameOrchestrator {
 
         for (idx, &player_id) in setup_order.iter().enumerate() {
             let round = if idx < total_placements / 2 { 1 } else { 2 };
-            println!(
-                "Setup Round {} — Player {} ({}) places settlement + road",
-                round, player_id, self.player_names[player_id]
-            );
 
             // Step 1: Choose settlement location.
             let legal_vertices = if round == 1 {
@@ -249,7 +237,6 @@ impl GameOrchestrator {
                 player_id, self.player_names[player_id],
                 vertex.hex.q, vertex.hex.r, vertex.dir, edge,
             );
-            println!("  {}", msg);
             self.send_ui(msg, None);
         }
 
@@ -260,12 +247,6 @@ impl GameOrchestrator {
     async fn run_turn(&mut self) -> Result<Option<PlayerId>, OrchestratorError> {
         let player_id = self.state.current_player();
 
-        println!(
-            "\n--- Turn {} — Player {} ({}) ---",
-            self.state.turn_number + 1,
-            player_id,
-            self.player_names[player_id],
-        );
 
         // Inject recent game history for LLM context (last 20 events).
         let recent_events = self.log.events();
@@ -283,7 +264,6 @@ impl GameOrchestrator {
         // Step 1: Roll dice.
         let (d1, d2) = dice::roll_dice(&mut rand::thread_rng());
         let roll = d1 + d2;
-        println!("  Rolled: {} + {} = {}", d1, d2, roll);
 
         let dice_event = GameEvent::DiceRolled {
             player: player_id,
@@ -328,7 +308,6 @@ impl GameOrchestrator {
             ).await;
 
             let choice = &choices[choice_idx.min(choices.len() - 1)];
-            println!("  Action: {} — {}", choice, reasoning);
             self.send_reasoning(player_id, &reasoning);
 
             let action_result = match choice {
@@ -362,9 +341,8 @@ impl GameOrchestrator {
                         return Ok(Some(winner));
                     }
                 }
-                Err(OrchestratorError::RuleViolation(msg)) => {
+                Err(OrchestratorError::RuleViolation(_msg)) => {
                     // Action was invalid — skip it and let the player try again.
-                    println!("  (Invalid action: {} — skipping)", msg);
                 }
                 Err(e) => return Err(e),
             }
@@ -437,10 +415,6 @@ impl GameOrchestrator {
         for &p in &players_needing_discard {
             let total = self.state.players[p].total_resources();
             let discard_count = (total / 2) as usize;
-            println!(
-                "  Player {} ({}) must discard {} cards",
-                p, self.player_names[p], discard_count
-            );
 
             // Set the discard phase so apply_discard works.
             self.state.phase = GamePhase::Discarding {
@@ -448,7 +422,7 @@ impl GameOrchestrator {
                 players_needing_discard: players_needing_discard.clone(),
             };
 
-            let (cards, reasoning) = self.with_timeout(
+            let (cards, _reasoning) = self.with_timeout(
                 p, "choose_discard",
                 self.players[p].choose_discard(&self.state, p, discard_count),
                 (Vec::new(), "timeout fallback".into()),
@@ -462,7 +436,6 @@ impl GameOrchestrator {
                 player: p,
                 cards: cards.clone(),
             });
-            println!("  Player {} discarded {} cards — {}", p, discard_count, reasoning);
         }
 
         // Step 2: Move robber.
@@ -475,7 +448,7 @@ impl GameOrchestrator {
             .filter(|&h| h != self.state.robber_hex)
             .collect();
 
-        let (h_idx, h_reasoning) = self.with_timeout(
+        let (h_idx, _h_reasoning) = self.with_timeout(
             roller, "choose_robber_hex",
             self.players[roller].choose_robber_hex(&self.state, roller, &legal_hexes),
             (0, "timeout fallback".into()),
@@ -485,16 +458,12 @@ impl GameOrchestrator {
         rules::apply_move_robber(&mut self.state, hex).map_err(|e| {
             OrchestratorError::RuleViolation(format!("Move robber: {}", e))
         })?;
-        println!(
-            "  Robber moved to ({},{}) — {}",
-            hex.q, hex.r, h_reasoning
-        );
 
         // Step 3: Steal (if in Stealing phase after move_robber).
         if let GamePhase::Stealing { target_hex, .. } = &self.state.phase {
             let targets = rules::steal_targets(&self.state, *target_hex, roller);
             if !targets.is_empty() {
-                let (t_idx, t_reasoning) = self.with_timeout(
+                let (t_idx, _t_reasoning) = self.with_timeout(
                     roller, "choose_steal_target",
                     self.players[roller].choose_steal_target(&self.state, roller, &targets),
                     (0, "timeout fallback".into()),
@@ -504,10 +473,6 @@ impl GameOrchestrator {
                 rules::apply_steal(&mut self.state, target).map_err(|e| {
                     OrchestratorError::RuleViolation(format!("Steal: {}", e))
                 })?;
-                println!(
-                    "  Stole from Player {} — {}",
-                    target, t_reasoning
-                );
 
                 self.record_event(GameEvent::RobberMoved {
                     player: roller,
@@ -531,7 +496,6 @@ impl GameOrchestrator {
         let distributions = dice::distribute_resources(&self.state, roll);
 
         if distributions.is_empty() {
-            println!("  No resources produced.");
             return;
         }
 
@@ -540,15 +504,6 @@ impl GameOrchestrator {
             for &(resource, count) in resources {
                 self.state.players[player].add_resource(resource, count);
             }
-            let summary: String = resources
-                .iter()
-                .map(|(r, c)| format!("{} {}", c, r))
-                .collect::<Vec<_>>()
-                .join(", ");
-            println!(
-                "  Player {} ({}) receives: {}",
-                player, self.player_names[player], summary
-            );
         }
 
         // Log the distributions.
@@ -601,10 +556,6 @@ impl GameOrchestrator {
         );
 
         self.apply_and_log(action, player_id, &h_reasoning)?;
-        println!(
-            "  Knight played: robber to ({},{}) — {}",
-            hex.q, hex.r, h_reasoning
-        );
         Ok(())
     }
 
@@ -622,7 +573,6 @@ impl GameOrchestrator {
 
         let action = Action::PlayDevCard(DevCard::Monopoly, DevCardAction::Monopoly(resource));
         self.apply_and_log(action, player_id, &reasoning)?;
-        println!("  Monopoly on {} — {}", resource, reasoning);
         Ok(())
     }
 
@@ -653,7 +603,6 @@ impl GameOrchestrator {
         let action =
             Action::PlayDevCard(DevCard::YearOfPlenty, DevCardAction::YearOfPlenty(r1, r2));
         self.apply_and_log(action, player_id, &reasoning)?;
-        println!("  Year of Plenty: {} + {} — {}", r1, r2, reasoning);
         Ok(())
     }
 
@@ -665,7 +614,6 @@ impl GameOrchestrator {
         // First road.
         let legal_edges_1 = rules::legal_road_edges(&self.state, player_id);
         if legal_edges_1.is_empty() {
-            println!("  No legal road placements for Road Building.");
             return Ok(());
         }
 
@@ -695,7 +643,6 @@ impl GameOrchestrator {
             DevCardAction::RoadBuilding(edge1, edge2),
         );
         self.apply_and_log(action, player_id, "Road Building")?;
-        println!("  Road Building: {} + {}", edge1, edge2);
         Ok(())
     }
 
@@ -711,14 +658,12 @@ impl GameOrchestrator {
         let (offer, reasoning) = match offer_result {
             Some((offer, reasoning)) => (offer, reasoning),
             None => {
-                println!("  Player {} decided not to trade.", player_id);
                 return Ok(());
             }
         };
 
         // Validate the offer using the trading module.
-        if let Err(e) = trading::negotiation::validate_trade(&self.state, &offer) {
-            println!("  Invalid trade offer: {}", e);
+        if let Err(_e) = trading::negotiation::validate_trade(&self.state, &offer) {
             return Ok(());
         }
 
@@ -735,14 +680,7 @@ impl GameOrchestrator {
             .collect::<Vec<_>>()
             .join(", ");
 
-        println!(
-            "  Trade proposed: giving [{}] for [{}] — {}",
-            offering, requesting, reasoning
-        );
         self.send_reasoning(player_id, &format!("Trade: {} for {} — {}", offering, requesting, reasoning));
-        if !offer.message.is_empty() {
-            println!("  Message: \"{}\"", offer.message);
-        }
 
         self.record_event(GameEvent::TradeProposed {
             from: player_id,
@@ -760,10 +698,6 @@ impl GameOrchestrator {
             }
 
             if !eligible.contains(&other_id) {
-                println!(
-                    "  Player {} ({}) cannot fulfill the trade.",
-                    other_id, self.player_names[other_id]
-                );
                 self.record_event(GameEvent::TradeRejected {
                     by: other_id,
                     reasoning: "Insufficient resources".into(),
@@ -779,10 +713,6 @@ impl GameOrchestrator {
 
             match response {
                 TradeResponse::Accept => {
-                    println!(
-                        "  Player {} ({}) accepts! — {}",
-                        other_id, self.player_names[other_id], resp_reasoning
-                    );
                     self.record_event(GameEvent::TradeAccepted {
                         by: other_id,
                         reasoning: resp_reasoning,
@@ -790,11 +720,7 @@ impl GameOrchestrator {
                     accepted_by = Some(other_id);
                     break; // First acceptance wins.
                 }
-                TradeResponse::Reject { reason } => {
-                    println!(
-                        "  Player {} ({}) rejects: {} — {}",
-                        other_id, self.player_names[other_id], reason, resp_reasoning
-                    );
+                TradeResponse::Reject { reason: _ } => {
                     self.record_event(GameEvent::TradeRejected {
                         by: other_id,
                         reasoning: resp_reasoning,
@@ -803,10 +729,6 @@ impl GameOrchestrator {
                 TradeResponse::Counter(counter_offer) => {
                     // Validate the counter-offer.
                     if let Err(e) = trading::negotiation::validate_trade(&self.state, &counter_offer) {
-                        println!(
-                            "  Player {} ({}) counter-offered but invalid: {} — {}",
-                            other_id, self.player_names[other_id], e, resp_reasoning
-                        );
                         self.record_event(GameEvent::TradeRejected {
                             by: other_id,
                             reasoning: format!("invalid counter: {}", e),
@@ -820,11 +742,6 @@ impl GameOrchestrator {
                     let counter_requesting: String = counter_offer.requesting.iter()
                         .map(|(r, n)| format!("{} {}", n, r))
                         .collect::<Vec<_>>().join(", ");
-                    println!(
-                        "  Player {} ({}) counter-offers: [{}] for [{}] — {}",
-                        other_id, self.player_names[other_id],
-                        counter_offering, counter_requesting, resp_reasoning
-                    );
                     self.send_reasoning(other_id, &format!(
                         "Counter: {} for {} — {}",
                         counter_offering, counter_requesting, resp_reasoning
@@ -845,10 +762,6 @@ impl GameOrchestrator {
 
                     match counter_response {
                         TradeResponse::Accept => {
-                            println!(
-                                "  Player {} ({}) accepts counter-offer! — {}",
-                                player_id, self.player_names[player_id], counter_reasoning
-                            );
                             self.record_event(GameEvent::TradeAccepted {
                                 by: player_id,
                                 reasoning: counter_reasoning,
@@ -857,24 +770,14 @@ impl GameOrchestrator {
                             match trading::negotiation::execute_in_state(
                                 &mut self.state, &counter_offer, player_id
                             ) {
-                                Ok(()) => {
-                                    println!(
-                                        "  Counter-trade executed between Player {} and Player {}!",
-                                        other_id, player_id
-                                    );
-                                }
-                                Err(e) => {
-                                    println!("  Counter-trade cancelled — {}", e);
+                                Ok(()) => {}
+                                Err(_) => {
                                     self.record_event(GameEvent::TradeWithdrawn { by: other_id });
                                 }
                             }
                             return Ok(());
                         }
                         _ => {
-                            println!(
-                                "  Player {} ({}) rejects counter-offer — {}",
-                                player_id, self.player_names[player_id], counter_reasoning
-                            );
                             self.record_event(GameEvent::TradeRejected {
                                 by: player_id,
                                 reasoning: counter_reasoning,
@@ -888,19 +791,11 @@ impl GameOrchestrator {
         // Step 3: Execute the trade using the trading module.
         if let Some(acceptor) = accepted_by {
             match trading::negotiation::execute_in_state(&mut self.state, &offer, acceptor) {
-                Ok(()) => {
-                    println!(
-                        "  Trade executed between Player {} and Player {}!",
-                        player_id, acceptor
-                    );
-                }
-                Err(e) => {
-                    println!("  Trade cancelled — {}", e);
+                Ok(()) => {}
+                Err(_) => {
                     self.record_event(GameEvent::TradeWithdrawn { by: player_id });
                 }
             }
-        } else {
-            println!("  No one accepted the trade.");
         }
 
         Ok(())
@@ -941,7 +836,6 @@ impl GameOrchestrator {
             has_rolled: false,
         };
         self.state.players[next].has_played_dev_card_this_turn = false;
-        println!("  Turn ended.");
     }
 }
 

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -3,6 +3,7 @@ pub mod llm;
 pub mod personality;
 pub mod prompt;
 pub mod random;
+pub mod tui_human;
 
 use async_trait::async_trait;
 

--- a/src/player/tui_human.rs
+++ b/src/player/tui_human.rs
@@ -1,0 +1,275 @@
+//! TUI-based human player that communicates with the ratatui UI via channels.
+//!
+//! The game engine sends decision prompts through a channel, and the TUI
+//! renders them as a selection overlay. The human picks with arrow keys + Enter,
+//! and the response flows back through a second channel.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex};
+
+use crate::game::actions::{PlayerId, TradeOffer, TradeResponse};
+use crate::game::board::{EdgeCoord, HexCoord, Resource, VertexCoord};
+use crate::game::state::GameState;
+use crate::player::{Player, PlayerChoice};
+
+/// A prompt sent from the game engine to the TUI for human input.
+pub struct HumanPrompt {
+    pub player_id: PlayerId,
+    pub title: String,
+    pub options: Vec<String>,
+}
+
+/// Shared channel endpoints for TUI↔engine human input.
+pub struct HumanInputChannel {
+    pub prompt_tx: mpsc::UnboundedSender<HumanPrompt>,
+    pub response_rx: Mutex<mpsc::UnboundedReceiver<usize>>,
+}
+
+/// A human player that integrates with the TUI via channels.
+pub struct TuiHumanPlayer {
+    name: String,
+    channel: Arc<HumanInputChannel>,
+}
+
+impl TuiHumanPlayer {
+    pub fn new(name: String, channel: Arc<HumanInputChannel>) -> Self {
+        Self { name, channel }
+    }
+
+    /// Send a prompt to the TUI and wait for the user's selection.
+    async fn pick_index(&self, player_id: PlayerId, title: String, options: Vec<String>) -> usize {
+        let max = options.len().saturating_sub(1);
+        let _ = self.channel.prompt_tx.send(HumanPrompt {
+            player_id,
+            title,
+            options,
+        });
+        let mut rx = self.channel.response_rx.lock().await;
+        rx.recv().await.unwrap_or(0).min(max)
+    }
+}
+
+const RESOURCE_NAMES: &[&str] = &["Wood", "Brick", "Sheep", "Wheat", "Ore"];
+const RESOURCES: &[Resource] = &[
+    Resource::Wood,
+    Resource::Brick,
+    Resource::Sheep,
+    Resource::Wheat,
+    Resource::Ore,
+];
+
+#[async_trait]
+impl Player for TuiHumanPlayer {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn choose_action(
+        &self,
+        _state: &GameState,
+        player_id: PlayerId,
+        choices: &[PlayerChoice],
+    ) -> (usize, String) {
+        let options: Vec<String> = choices.iter().map(|c| format!("{}", c)).collect();
+        let idx = self.pick_index(player_id, "Choose action".into(), options).await;
+        (idx, String::new())
+    }
+
+    async fn choose_settlement(
+        &self,
+        _state: &GameState,
+        player_id: PlayerId,
+        legal_vertices: &[VertexCoord],
+    ) -> (usize, String) {
+        let options: Vec<String> = legal_vertices
+            .iter()
+            .map(|v| format!("({},{},{:?})", v.hex.q, v.hex.r, v.dir))
+            .collect();
+        let idx = self
+            .pick_index(player_id, "Place settlement".into(), options)
+            .await;
+        (idx, String::new())
+    }
+
+    async fn choose_road(
+        &self,
+        _state: &GameState,
+        player_id: PlayerId,
+        legal_edges: &[EdgeCoord],
+    ) -> (usize, String) {
+        let options: Vec<String> = legal_edges.iter().map(|e| format!("{}", e)).collect();
+        let idx = self
+            .pick_index(player_id, "Place road".into(), options)
+            .await;
+        (idx, String::new())
+    }
+
+    async fn choose_robber_hex(
+        &self,
+        _state: &GameState,
+        player_id: PlayerId,
+        legal_hexes: &[HexCoord],
+    ) -> (usize, String) {
+        let options: Vec<String> = legal_hexes
+            .iter()
+            .map(|h| format!("({},{})", h.q, h.r))
+            .collect();
+        let idx = self
+            .pick_index(player_id, "Move robber".into(), options)
+            .await;
+        (idx, String::new())
+    }
+
+    async fn choose_steal_target(
+        &self,
+        state: &GameState,
+        player_id: PlayerId,
+        targets: &[PlayerId],
+    ) -> (usize, String) {
+        let options: Vec<String> = targets
+            .iter()
+            .map(|&p| {
+                format!(
+                    "Player {} ({} cards)",
+                    p,
+                    state.players[p].total_resources()
+                )
+            })
+            .collect();
+        let idx = self
+            .pick_index(player_id, "Steal from".into(), options)
+            .await;
+        (idx, String::new())
+    }
+
+    async fn choose_discard(
+        &self,
+        state: &GameState,
+        player_id: PlayerId,
+        count: usize,
+    ) -> (Vec<Resource>, String) {
+        let ps = &state.players[player_id];
+        let mut discards = Vec::with_capacity(count);
+        // Track remaining resources as we pick
+        let mut remaining = [
+            ps.resource_count(Resource::Wood),
+            ps.resource_count(Resource::Brick),
+            ps.resource_count(Resource::Sheep),
+            ps.resource_count(Resource::Wheat),
+            ps.resource_count(Resource::Ore),
+        ];
+
+        for i in 0..count {
+            let mut options = Vec::new();
+            let mut resource_indices = Vec::new();
+            for (j, &name) in RESOURCE_NAMES.iter().enumerate() {
+                if remaining[j] > 0 {
+                    options.push(format!("{} (have {})", name, remaining[j]));
+                    resource_indices.push(j);
+                }
+            }
+            let title = format!("Discard card {}/{}", i + 1, count);
+            let idx = self.pick_index(player_id, title, options).await;
+            let res_idx = resource_indices[idx.min(resource_indices.len() - 1)];
+            remaining[res_idx] -= 1;
+            discards.push(RESOURCES[res_idx]);
+        }
+
+        (discards, String::new())
+    }
+
+    async fn choose_resource(
+        &self,
+        _state: &GameState,
+        player_id: PlayerId,
+        context: &str,
+    ) -> (Resource, String) {
+        let options: Vec<String> = RESOURCE_NAMES.iter().map(|s| s.to_string()).collect();
+        let idx = self.pick_index(player_id, context.to_string(), options).await;
+        (RESOURCES[idx.min(RESOURCES.len() - 1)], String::new())
+    }
+
+    async fn propose_trade(
+        &self,
+        state: &GameState,
+        player_id: PlayerId,
+    ) -> Option<(TradeOffer, String)> {
+        let ps = &state.players[player_id];
+
+        // Pick resource to give (only show resources the player has)
+        let mut give_options = Vec::new();
+        let mut give_indices = Vec::new();
+        for (i, &name) in RESOURCE_NAMES.iter().enumerate() {
+            let count = ps.resource_count(RESOURCES[i]);
+            if count > 0 {
+                give_options.push(format!("{} (have {})", name, count));
+                give_indices.push(i);
+            }
+        }
+        give_options.push("Cancel".into());
+
+        let give_idx = self
+            .pick_index(player_id, "Trade: give what?".into(), give_options.clone())
+            .await;
+        if give_idx >= give_indices.len() {
+            return None; // cancelled
+        }
+        let give_resource = RESOURCES[give_indices[give_idx]];
+
+        // Pick resource to request
+        let mut get_options: Vec<String> = RESOURCE_NAMES.iter().map(|s| s.to_string()).collect();
+        get_options.push("Cancel".into());
+        let get_idx = self
+            .pick_index(player_id, "Trade: want what?".into(), get_options)
+            .await;
+        if get_idx >= RESOURCES.len() {
+            return None;
+        }
+        let get_resource = RESOURCES[get_idx];
+
+        Some((
+            TradeOffer {
+                from: player_id,
+                offering: vec![(give_resource, 1)],
+                requesting: vec![(get_resource, 1)],
+                message: String::new(),
+            },
+            String::new(),
+        ))
+    }
+
+    async fn respond_to_trade(
+        &self,
+        _state: &GameState,
+        player_id: PlayerId,
+        offer: &TradeOffer,
+    ) -> (TradeResponse, String) {
+        let offering: String = offer
+            .offering
+            .iter()
+            .map(|(r, n)| format!("{} {}", n, r))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let requesting: String = offer
+            .requesting
+            .iter()
+            .map(|(r, n)| format!("{} {}", n, r))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let title = format!("P{} offers [{}] for [{}]", offer.from, offering, requesting);
+        let options = vec!["Accept".into(), "Reject".into()];
+        let idx = self.pick_index(player_id, title, options).await;
+        if idx == 0 {
+            (TradeResponse::Accept, String::new())
+        } else {
+            (
+                TradeResponse::Reject {
+                    reason: "Declined".into(),
+                },
+                String::new(),
+            )
+        }
+    }
+}

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,7 +1,7 @@
 //! TUI layout — splits the terminal into board, players, and log panels.
 
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use super::PlayingState;
 use super::board_view;
@@ -108,4 +108,63 @@ pub fn draw_playing(f: &mut Frame, ps: &PlayingState) {
     ]);
     let status_paragraph = Paragraph::new(status);
     f.render_widget(status_paragraph, main_chunks[2]);
+
+    // Human input overlay.
+    if let Some(ref prompt) = ps.pending_prompt {
+        draw_human_prompt(f, prompt);
+    }
+}
+
+/// Draw a centered popup overlay for human player input.
+fn draw_human_prompt(f: &mut Frame, prompt: &super::PendingHumanPrompt) {
+    let area = f.area();
+
+    // Size the popup to fit the content.
+    let max_option_len = prompt.options.iter().map(|o| o.len()).max().unwrap_or(10);
+    let popup_width = (max_option_len as u16 + 8).max(prompt.title.len() as u16 + 6).min(area.width - 4);
+    let popup_height = (prompt.options.len() as u16 + 4).min(area.height - 2);
+
+    let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+    let popup_y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+    let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+    // Clear the area behind the popup.
+    f.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(format!(" {} ", prompt.title))
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow).bold());
+    f.render_widget(block, popup_area);
+
+    // Render options inside the block.
+    let inner = Rect::new(popup_x + 2, popup_y + 1, popup_width - 4, popup_height - 2);
+    for (i, option) in prompt.options.iter().enumerate() {
+        let y = inner.y + i as u16;
+        if y >= inner.y + inner.height {
+            break;
+        }
+        let is_selected = i == prompt.selected;
+        let marker = if is_selected { ">" } else { " " };
+        let style = if is_selected {
+            Style::default().fg(Color::Black).bg(Color::Cyan).bold()
+        } else {
+            Style::default().fg(Color::White)
+        };
+        let line_area = Rect::new(inner.x, y, inner.width, 1);
+        let text = format!("{} {}", marker, option);
+        let para = Paragraph::new(text).style(style);
+        f.render_widget(para, line_area);
+    }
+
+    // Hint at bottom of popup.
+    let hint_y = popup_y + popup_height - 1;
+    if hint_y > popup_y {
+        let hint_area = Rect::new(popup_x + 1, hint_y, popup_width - 2, 1);
+        let hint = Paragraph::new(" [↑↓] select  [Enter] confirm ")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::DarkGray));
+        f.render_widget(hint, hint_area);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::ExecutableCommand;
 use ratatui::prelude::*;
@@ -69,6 +69,13 @@ pub enum Screen {
     PostGame(PostGameState),
 }
 
+/// A pending human input prompt displayed as an overlay.
+pub struct PendingHumanPrompt {
+    pub title: String,
+    pub options: Vec<String>,
+    pub selected: usize,
+}
+
 /// State for the active game screen (formerly the flat App fields).
 pub struct PlayingState {
     pub rx: mpsc::UnboundedReceiver<UiEvent>,
@@ -82,15 +89,26 @@ pub struct PlayingState {
     pub chat_scroll: u16,
     pub speed_ms: u64,
     pub paused: bool,
+    /// Pending human decision prompt (shown as an overlay).
+    pub pending_prompt: Option<PendingHumanPrompt>,
+    /// Channel to receive human prompts from the engine.
+    pub human_prompt_rx: Option<mpsc::UnboundedReceiver<player::tui_human::HumanPrompt>>,
+    /// Channel to send human responses back to the engine.
+    pub human_response_tx: Option<mpsc::UnboundedSender<usize>>,
 }
 
 impl PlayingState {
-    fn new(rx: mpsc::UnboundedReceiver<UiEvent>, player_names: Vec<String>) -> Self {
+    fn new(rx: mpsc::UnboundedReceiver<UiEvent>, player_names: Vec<String>, has_human: bool) -> Self {
+        let start_msg = if has_human {
+            "Game started — your turn will show a prompt".into()
+        } else {
+            "Game started — spectator mode".into()
+        };
         Self {
             rx,
             state: None,
             messages: vec![
-                "Game started — spectator mode".into(),
+                start_msg,
                 "q:quit  Space:pause  +/-:speed  j/k:scroll".into(),
             ],
             chat_messages: Vec::new(),
@@ -101,6 +119,9 @@ impl PlayingState {
             chat_scroll: 0,
             speed_ms: 100,
             paused: false,
+            pending_prompt: None,
+            human_prompt_rx: None,
+            human_response_tx: None,
         }
     }
 
@@ -204,6 +225,12 @@ async fn run_event_loop(
         if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 if key.kind == KeyEventKind::Press {
+                    // Ctrl+C exits from any screen.
+                    if key.modifiers.contains(KeyModifiers::CONTROL)
+                        && key.code == KeyCode::Char('c')
+                    {
+                        return Ok(());
+                    }
                     let action = handle_input(app, key.code);
                     match action {
                         Action::None => {}
@@ -248,6 +275,19 @@ async fn run_event_loop(
             if !ps.paused {
                 while let Ok(ui_event) = ps.rx.try_recv() {
                     ps.handle_game_event(ui_event);
+                }
+            }
+
+            // Check for incoming human prompts.
+            if ps.pending_prompt.is_none() {
+                if let Some(ref mut prompt_rx) = ps.human_prompt_rx {
+                    if let Ok(prompt) = prompt_rx.try_recv() {
+                        ps.pending_prompt = Some(PendingHumanPrompt {
+                            title: prompt.title,
+                            options: prompt.options,
+                            selected: 0,
+                        });
+                    }
                 }
             }
         }
@@ -403,6 +443,29 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
         }
 
         Screen::Playing(ps) => {
+            // If a human prompt is pending, intercept input for selection.
+            if let Some(ref mut prompt) = ps.pending_prompt {
+                match key {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        prompt.selected = prompt.selected.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if prompt.selected + 1 < prompt.options.len() {
+                            prompt.selected += 1;
+                        }
+                    }
+                    KeyCode::Enter => {
+                        let selected = prompt.selected;
+                        if let Some(ref tx) = ps.human_response_tx {
+                            let _ = tx.send(selected);
+                        }
+                        ps.pending_prompt = None;
+                    }
+                    _ => {}
+                }
+                return Action::None;
+            }
+
             match key {
                 KeyCode::Char('q') | KeyCode::Esc => {
                     if ps.game_over {
@@ -609,6 +672,10 @@ fn cycle_new_game_value(state: &mut NewGameState, forward: bool) {
 // ── Game Launch ────────────────────────────────────────────────────────
 
 fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> Screen {
+    use std::sync::Arc;
+    use player::tui_human::{HumanInputChannel, TuiHumanPlayer};
+    use tokio::sync::Mutex;
+
     // Build board.
     let board = if let Some(seed) = ng.seed() {
         use rand::SeedableRng;
@@ -629,6 +696,20 @@ fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> S
         Personality::builder(),
         Personality::chaos_agent(),
     ];
+
+    // Create human input channels if any human players exist.
+    let has_human = ng.players.iter().any(|p| p.kind == PlayerKind::Human);
+    let human_channels = if has_human {
+        let (prompt_tx, prompt_rx) = mpsc::unbounded_channel();
+        let (response_tx, response_rx) = mpsc::unbounded_channel();
+        let channel = Arc::new(HumanInputChannel {
+            prompt_tx,
+            response_rx: Mutex::new(response_rx),
+        });
+        Some((channel, prompt_rx, response_tx))
+    } else {
+        None
+    };
 
     let players: Vec<Box<dyn player::Player>> = ng.players.iter().map(|pc| {
         match pc.kind {
@@ -653,10 +734,9 @@ fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> S
                     as Box<dyn player::Player>
             }
             PlayerKind::Human => {
-                Box::new(player::random::RandomPlayer::new(pc.name.clone()))
+                let channel = human_channels.as_ref().unwrap().0.clone();
+                Box::new(TuiHumanPlayer::new(pc.name.clone(), channel))
                     as Box<dyn player::Player>
-                // TODO: Wire HumanPlayer through TUI input overlay.
-                // For now, Human falls back to Random in TUI mode.
             }
         }
     }).collect();
@@ -698,7 +778,12 @@ fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> S
         result
     });
 
-    Screen::Playing(PlayingState::new(rx, player_names))
+    let mut ps = PlayingState::new(rx, player_names, has_human);
+    if let Some((_, prompt_rx, response_tx)) = human_channels {
+        ps.human_prompt_rx = Some(prompt_rx);
+        ps.human_response_tx = Some(response_tx);
+    }
+    Screen::Playing(ps)
 }
 
 fn launch_resume(path: &std::path::Path) -> Option<Screen> {
@@ -743,7 +828,7 @@ fn launch_resume(path: &std::path::Path) -> Option<Screen> {
         result
     });
 
-    Some(Screen::Playing(PlayingState::new(rx, player_names)))
+    Some(Screen::Playing(PlayingState::new(rx, player_names, false)))
 }
 
 fn launch_replay(path: &std::path::Path) -> Option<Screen> {
@@ -787,7 +872,7 @@ fn launch_replay(path: &std::path::Path) -> Option<Screen> {
             }
         });
 
-        return Some(Screen::Playing(PlayingState::new(rx, player_names)));
+        return Some(Screen::Playing(PlayingState::new(rx, player_names, false)));
     }
 
     // Fall back to JSONL event log — simpler playback.
@@ -809,7 +894,7 @@ fn launch_replay(path: &std::path::Path) -> Option<Screen> {
             }
         });
 
-        return Some(Screen::Playing(PlayingState::new(rx, player_names)));
+        return Some(Screen::Playing(PlayingState::new(rx, player_names, false)));
     }
 
     None


### PR DESCRIPTION
## Summary
- Removed ~40 `println!()` calls from orchestrator that were writing directly to stdout while ratatui owned the alternate screen, causing garbled overlapping text
- Added `TuiHumanPlayer` with channel-based communication -- selecting "Human" in new game setup now shows an interactive selection overlay instead of silently falling back to RandomPlayer
- Ctrl+C now exits cleanly from any screen
- Updated CLAUDE.md with coding style, testing, and commit guidelines

## Test plan
- [x] `cargo test` -- all 158 tests pass
- [x] `cargo build` -- compiles with no errors
- [ ] Manual: launch TUI, verify no garbled text during game
- [ ] Manual: create game with human player, verify popup overlay appears on your turn


🤖 Generated with [Claude Code](https://claude.com/claude-code)