### PR TITLE
fix: bump crossterm 0.28→0.29, fix rand 0.9 API migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,22 +448,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -474,7 +458,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -658,7 +642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1433,12 +1417,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1834,7 +1812,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1879,7 +1857,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1902,7 +1880,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1928,12 +1906,21 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1943,8 +1930,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1961,7 +1954,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2005,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm 0.29.0",
+ "crossterm",
  "instability",
  "ratatui-core",
 ]
@@ -2181,19 +2174,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2201,8 +2181,8 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2259,7 +2239,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2471,11 +2451,11 @@ dependencies = [
  "async-trait",
  "cargo-husky",
  "clap",
- "crossterm 0.28.1",
+ "crossterm",
  "genai",
  "insta",
  "proptest",
- "rand",
+ "rand 0.9.2",
  "ratatui",
  "reqwest",
  "serde",
@@ -2711,8 +2691,8 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3468,7 +3448,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3561,15 +3541,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 rand = "0.9"
-crossterm = "0.28"
+crossterm = "0.29"
 toml = "1.0"
 genai = "0.6.0-beta.13"
 async-trait = "0.1.89"

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -739,7 +739,7 @@ mod tests {
     use std::collections::HashSet;
 
     fn make_board() -> Board {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         Board::generate(&mut rng)
     }
 

--- a/src/game/dice.rs
+++ b/src/game/dice.rs
@@ -8,7 +8,7 @@ use crate::game::state::{Building, GameState};
 
 /// Roll two six-sided dice, returning each die's value.
 pub fn roll_dice(rng: &mut impl Rng) -> (u8, u8) {
-    (rng.gen_range(1..=6), rng.gen_range(1..=6))
+    (rng.random_range(1..=6), rng.random_range(1..=6))
 }
 
 /// Calculate resource distribution for a given dice roll.

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -266,7 +266,7 @@ impl GameOrchestrator {
             .await;
 
         // Step 1: Roll dice.
-        let (d1, d2) = dice::roll_dice(&mut rand::thread_rng());
+        let (d1, d2) = dice::roll_dice(&mut rand::rng());
         let roll = d1 + d2;
 
         let dice_event = GameEvent::DiceRolled {

--- a/src/game/rules.rs
+++ b/src/game/rules.rs
@@ -896,8 +896,8 @@ pub fn steal_random_resource(state: &mut GameState, thief: PlayerId, victim: Pla
     }
 
     // Pick one at random.
-    use rand::seq::SliceRandom;
-    let mut rng = rand::thread_rng();
+    use rand::seq::IndexedRandom;
+    let mut rng = rand::rng();
     if let Some(&stolen) = pool.choose(&mut rng) {
         state.players[victim].remove_resource(stolen, 1);
         state.players[thief].add_resource(stolen, 1);

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use rand::seq::SliceRandom;
+use rand::seq::SliceRandom as _;
 use serde::{Deserialize, Serialize};
 
 use crate::game::actions::{DevCard, PlayerId};
@@ -200,7 +200,7 @@ impl GameState {
             dev_card_deck.push(DevCard::Monopoly);
         }
         {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             dev_card_deck.shuffle(&mut rng);
         }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -80,7 +80,7 @@ pub async fn run(cli: HeadlessCli) {
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         game::board::Board::generate(&mut rng)
     } else {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         game::board::Board::generate(&mut rng)
     };
 

--- a/src/player/llm.rs
+++ b/src/player/llm.rs
@@ -315,7 +315,7 @@ impl Player for LlmPlayer {
             Err(_) => {
                 // Random fallback.
                 use rand::Rng;
-                let idx = rand::thread_rng().gen_range(0..choices.len());
+                let idx = rand::rng().random_range(0..choices.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
         }
@@ -338,7 +338,7 @@ impl Player for LlmPlayer {
             }
             Err(_) => {
                 use rand::Rng;
-                let idx = rand::thread_rng().gen_range(0..legal_vertices.len());
+                let idx = rand::rng().random_range(0..legal_vertices.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
         }
@@ -361,7 +361,7 @@ impl Player for LlmPlayer {
             }
             Err(_) => {
                 use rand::Rng;
-                let idx = rand::thread_rng().gen_range(0..legal_edges.len());
+                let idx = rand::rng().random_range(0..legal_edges.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
         }
@@ -390,7 +390,7 @@ impl Player for LlmPlayer {
             }
             Err(_) => {
                 use rand::Rng;
-                let idx = rand::thread_rng().gen_range(0..legal_hexes.len());
+                let idx = rand::rng().random_range(0..legal_hexes.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
         }
@@ -429,7 +429,7 @@ impl Player for LlmPlayer {
             }
             Err(_) => {
                 use rand::Rng;
-                let idx = rand::thread_rng().gen_range(0..targets.len());
+                let idx = rand::rng().random_range(0..targets.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
         }

--- a/src/player/random.rs
+++ b/src/player/random.rs
@@ -32,7 +32,7 @@ impl Player for RandomPlayer {
         _player_id: PlayerId,
         choices: &[PlayerChoice],
     ) -> (usize, String) {
-        let idx = rand::thread_rng().gen_range(0..choices.len());
+        let idx = rand::rng().random_range(0..choices.len());
         (idx, format!("[random] chose: {}", choices[idx]))
     }
 
@@ -42,7 +42,7 @@ impl Player for RandomPlayer {
         _player_id: PlayerId,
         legal_vertices: &[VertexCoord],
     ) -> (usize, String) {
-        let idx = rand::thread_rng().gen_range(0..legal_vertices.len());
+        let idx = rand::rng().random_range(0..legal_vertices.len());
         (idx, "[random settlement]".into())
     }
 
@@ -52,7 +52,7 @@ impl Player for RandomPlayer {
         _player_id: PlayerId,
         legal_edges: &[EdgeCoord],
     ) -> (usize, String) {
-        let idx = rand::thread_rng().gen_range(0..legal_edges.len());
+        let idx = rand::rng().random_range(0..legal_edges.len());
         (idx, "[random road]".into())
     }
 
@@ -62,7 +62,7 @@ impl Player for RandomPlayer {
         _player_id: PlayerId,
         legal_hexes: &[HexCoord],
     ) -> (usize, String) {
-        let idx = rand::thread_rng().gen_range(0..legal_hexes.len());
+        let idx = rand::rng().random_range(0..legal_hexes.len());
         (idx, "[random robber]".into())
     }
 
@@ -72,7 +72,7 @@ impl Player for RandomPlayer {
         _player_id: PlayerId,
         targets: &[PlayerId],
     ) -> (usize, String) {
-        let idx = rand::thread_rng().gen_range(0..targets.len());
+        let idx = rand::rng().random_range(0..targets.len());
         (idx, "[random steal]".into())
     }
 
@@ -93,7 +93,7 @@ impl Player for RandomPlayer {
         }
 
         use rand::seq::SliceRandom;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         pool.shuffle(&mut rng);
         pool.truncate(count);
 
@@ -107,7 +107,7 @@ impl Player for RandomPlayer {
         _context: &str,
     ) -> (Resource, String) {
         let all = Resource::all();
-        let idx = rand::thread_rng().gen_range(0..all.len());
+        let idx = rand::rng().random_range(0..all.len());
         (all[idx], "[random resource]".into())
     }
 
@@ -134,9 +134,9 @@ impl Player for RandomPlayer {
         }
 
         use rand::Rng;
-        let mut rng = rand::thread_rng();
-        let give = have[rng.gen_range(0..have.len())];
-        let get = want[rng.gen_range(0..want.len())];
+        let mut rng = rand::rng();
+        let give = have[rng.random_range(0..have.len())];
+        let get = want[rng.random_range(0..want.len())];
 
         Some((
             TradeOffer {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1333,7 +1333,7 @@ fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> S
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         Board::generate(&mut rng)
     } else {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         Board::generate(&mut rng)
     };
 


### PR DESCRIPTION
## Summary
- Bumps crossterm from 0.28.1 to 0.29.0 (supersedes #13 which had Cargo.lock conflicts)
- Fixes rand 0.9 API migration that Dependabot missed in #11 (code was using deprecated `thread_rng`, `gen_range`, and removed `SliceRandom::choose`)
- All 241 tests pass, clippy clean, fmt clean

## Changes
- `rand::thread_rng()` → `rand::rng()`
- `rng.gen_range()` → `rng.random_range()`
- `rand::seq::SliceRandom` (for `choose`) → `rand::seq::IndexedRandom`
- `crossterm` version bump in Cargo.toml

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)