### PR TITLE
feat: full resource names on hex tiles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -36,16 +36,16 @@
 | Hex interior | Terrain + number + dots | Each on dedicated row (see template) |
 | Hot numbers (6, 8) | bold + bright white | High probability, must stand out |
 
-### Terrain Abbreviations
-Resource-based abbreviations (what the terrain produces, not terrain name):
-| Terrain | Abbrev | Produces |
-|---------|--------|----------|
-| Forest | `Wo` | Wood |
-| Hills | `Bk` | Brick |
-| Pasture | `Sh` | Sheep |
-| Fields | `Wh` | Wheat |
-| Mountains | `Or` | Ore |
-| Desert | `De` | Nothing |
+### Terrain Labels
+Full resource names displayed on hex tiles (what the terrain produces, not terrain name):
+| Terrain | Label | Produces |
+|---------|-------|----------|
+| Forest | `Wood` | Wood |
+| Hills | `Brick` | Brick |
+| Pasture | `Sheep` | Sheep |
+| Fields | `Wheat` | Wheat |
+| Mountains | `Ore` | Ore |
+| Desert | `Desert` | Nothing |
 
 ### Number Probability Dots
 Display below the number token inside each hex to show roll probability:
@@ -159,7 +159,7 @@ Pointy-top hexes, interlocking. Each hex cell:
             ╱   ╲             <- cy-4: upper diagonals
           ╱       ╲           <- cy-3: wider diagonals
         ╱           ╲         <- cy-2: even wider
-      ╱   Wo          ╲      <- cy-1: TERRAIN label (dedicated row)
+      ╱   Wood         ╲      <- cy-1: TERRAIN label (dedicated row)
      ·       6          ·     <- cy:   NUMBER token (dedicated row)
       ╲    ·····      ╱      <- cy+1: PROBABILITY DOTS (dedicated row)
         ╲           ╱         <- cy+2: lower diagonals

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -179,7 +179,7 @@ impl Terrain {
         }
     }
 
-    /// Two-character abbreviation for display in ASCII and TUI boards.
+    /// Two-character abbreviation for display in ASCII boards and LLM prompts.
     pub fn abbr(self) -> &'static str {
         match self {
             Terrain::Forest => "Wo",
@@ -188,6 +188,18 @@ impl Terrain {
             Terrain::Fields => "Wh",
             Terrain::Mountains => "Or",
             Terrain::Desert => "De",
+        }
+    }
+
+    /// Full resource label for display on TUI hex tiles.
+    pub fn label(self) -> &'static str {
+        match self {
+            Terrain::Forest => "Wood",
+            Terrain::Hills => "Brick",
+            Terrain::Pasture => "Sheep",
+            Terrain::Fields => "Wheat",
+            Terrain::Mountains => "Ore",
+            Terrain::Desert => "Desert",
         }
     }
 }
@@ -1090,5 +1102,15 @@ mod tests {
         assert_eq!(Terrain::Fields.abbr(), "Wh");
         assert_eq!(Terrain::Mountains.abbr(), "Or");
         assert_eq!(Terrain::Desert.abbr(), "De");
+    }
+
+    #[test]
+    fn terrain_label_covers_all_variants() {
+        assert_eq!(Terrain::Forest.label(), "Wood");
+        assert_eq!(Terrain::Hills.label(), "Brick");
+        assert_eq!(Terrain::Pasture.label(), "Sheep");
+        assert_eq!(Terrain::Fields.label(), "Wheat");
+        assert_eq!(Terrain::Mountains.label(), "Ore");
+        assert_eq!(Terrain::Desert.label(), "Desert");
     }
 }

--- a/src/ui/board_view.rs
+++ b/src/ui/board_view.rs
@@ -312,7 +312,7 @@ fn draw_hex_cell(
     }
 
     // Terrain label on row cy-1
-    let abbr = hex.terrain.abbr();
+    let label = hex.terrain.label();
     let text_style = if is_robber {
         Style::default().fg(Color::White).bg(Color::Red).bold()
     } else {
@@ -321,12 +321,14 @@ fn draw_hex_cell(
 
     if is_robber {
         set_cell(cx - 5, cy - 1, 'R', text_style, area, buf);
-        for (i, ch) in abbr.chars().enumerate() {
-            set_cell(cx - 3 + i as i16, cy - 1, ch, text_style, area, buf);
+        let label_start = cx - 3;
+        for (i, ch) in label.chars().enumerate() {
+            set_cell(label_start + i as i16, cy - 1, ch, text_style, area, buf);
         }
     } else {
-        for (i, ch) in abbr.chars().enumerate() {
-            set_cell(cx - 4 + i as i16, cy - 1, ch, text_style, area, buf);
+        let label_start = cx - (label.len() as i16) / 2;
+        for (i, ch) in label.chars().enumerate() {
+            set_cell(label_start + i as i16, cy - 1, ch, text_style, area, buf);
         }
     }
 

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
@@ -9,7 +9,7 @@ expression: buffer_to_string(&buf)
 │                                          *                                   │
 │                                                                              │
 │                                                                              │
-│                            Bk                  Bk                  Bk        │
+│                              Brick               Brick               Brick   │
 │                                5                   2                   6     │
 │                                                                              │
 │                                                                              │
@@ -18,7 +18,7 @@ expression: buffer_to_string(&buf)
 │            *                                                                 │
 │                                                                              │
 │                                                                              │
-│                  Wo                  Wo                  Wo                  │
+│                    Wood                Wood                Wood              │
 │                      3                   8                  10               │
 │                                                                              │
 │                                                                              │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                              ◇                   *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
@@ -12,7 +12,7 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                            Bk                  Bk                  Bk                                                    ││ P3 Diana 0VP               │
+│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
 │                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wo                  Wo                  Wo                  Wo                                          │└────────────────────────────┘
+│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
 │                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
@@ -30,7 +30,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                        Or                  Or                  Or                  Wh                  Wh                                ││                            │
+│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
 │                           12                  11                   4                   8                  10                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,7 +39,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                  Wh                  Wh                  Sh                  Sh                                          ││                            │
+│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
 │                                      9                   4                   5                   6                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,7 +48,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                            Sh                  Sh                 R De                                                   ││                            │
+│                                              Sheep               Sheep            R Desert                                               ││                            │
 │                                                3                  11                   R                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │


### PR DESCRIPTION
## Description

Display full resource names (Wood, Brick, Sheep, Wheat, Ore, Desert) on hex tiles instead of two-character abbreviations (Wo, Bk, Sh, Wh, Or, De). Now that tiles are bigger (#21 scaled hexes from 12x7 to 16x9), there's plenty of room for the full label.

- Added `Terrain::label()` method for full resource names (TUI display)
- Preserved `Terrain::abbr()` for LLM prompts (no change to AI behavior)
- Centered labels on the hex tile row `cy-1`
- Updated DESIGN.md terrain label spec and hex template
- Added test for new `label()` method

Fixes #19

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)