### PR TITLE
feat: remove max turns setting, lock player 1 to human

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -26,10 +26,6 @@ pub struct HeadlessCli {
     #[arg(short, long, default_value = "claude-sonnet-4-6")]
     pub model: String,
 
-    /// Maximum turns before ending the game
-    #[arg(long, default_value = "500")]
-    pub max_turns: u32,
-
     /// Per-player models, comma-separated
     #[arg(long)]
     pub models: Option<String>,
@@ -64,7 +60,7 @@ pub async fn run(cli: HeadlessCli) {
 
     // Handle resume mode.
     if let Some(ref save_path) = cli.resume {
-        run_resume(save_path, &cli).await;
+        run_resume(save_path).await;
         return;
     }
 
@@ -151,7 +147,6 @@ pub async fn run(cli: HeadlessCli) {
     }
 
     let mut orchestrator = game::orchestrator::GameOrchestrator::new(state, players);
-    orchestrator.max_turns = cli.max_turns;
 
     match orchestrator.run().await {
         Ok(_winner) => {
@@ -257,7 +252,7 @@ fn run_replay(replay_path: &str) {
     }
 }
 
-async fn run_resume(save_path: &str, cli: &HeadlessCli) {
+async fn run_resume(save_path: &str) {
     let path = std::path::Path::new(save_path);
     match replay::save::SaveGame::load_from_file(path) {
         Ok(save) => {
@@ -291,7 +286,6 @@ async fn run_resume(save_path: &str, cli: &HeadlessCli) {
             let log = save.recent_log();
             let mut orchestrator = game::orchestrator::GameOrchestrator::new(save.state, players);
             orchestrator.log = log;
-            orchestrator.max_turns = cli.max_turns;
 
             match orchestrator.run().await {
                 Ok(winner) => {

--- a/src/ui/flow_tests.rs
+++ b/src/ui/flow_tests.rs
@@ -217,13 +217,11 @@ fn screen_navigation_new_game_configure_and_start() {
 
     // Navigate down to the start button.
     // Default focus is Player { row: 0, col: Kind }.
-    // Down x4 goes through player rows, then Settings, then StartButton.
+    // Down x4 goes through player rows, then Seed, then StartButton.
     for _ in 0..4 {
         handle_input(&mut app, KeyCode::Down);
     }
-    // Now at Setting(0) = seed.
-    handle_input(&mut app, KeyCode::Down);
-    // Now at Setting(1) = max_turns.
+    // Now at Seed.
     handle_input(&mut app, KeyCode::Down);
     // Now at StartButton.
 

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -144,6 +144,48 @@ fn new_game_focus_navigation() {
     }
 }
 
+#[test]
+fn new_game_player_0_kind_locked_to_human() {
+    let mut app = new_game_app();
+    // Focus is on Player { row: 0, col: Kind }. Cycling should not change it.
+    handle_input(&mut app, KeyCode::Right); // cycle forward
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(
+            state.players[0].kind,
+            PlayerKind::Human,
+            "player 0 should always be Human"
+        );
+    }
+    handle_input(&mut app, KeyCode::Left); // cycle backward
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(
+            state.players[0].kind,
+            PlayerKind::Human,
+            "player 0 should always be Human"
+        );
+    }
+}
+
+#[test]
+fn new_game_ai_players_cannot_be_human() {
+    let mut app = new_game_app();
+    // Navigate to player 1's Kind column.
+    handle_input(&mut app, KeyCode::Down);
+    // Player 1 starts as Random. Cycle through all options.
+    handle_input(&mut app, KeyCode::Right); // Random -> Llm
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.players[1].kind, PlayerKind::Llm);
+    }
+    handle_input(&mut app, KeyCode::Right); // Llm -> Random (skips Human)
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(
+            state.players[1].kind,
+            PlayerKind::Random,
+            "should cycle back to Random, never Human"
+        );
+    }
+}
+
 // ── ActionBar ────────────────────────────────────────────────────────
 
 #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -660,7 +660,7 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                             state.editing = true;
                             Action::None
                         }
-                        NewGameFocus::Setting(_) => {
+                        NewGameFocus::Seed => {
                             state.editing = true;
                             Action::None
                         }
@@ -1199,11 +1199,8 @@ fn handle_new_game_editing(state: &mut NewGameState, key: KeyCode) -> Action {
                 } => {
                     state.players[row].name.pop();
                 }
-                NewGameFocus::Setting(0) => {
+                NewGameFocus::Seed => {
                     state.seed_input.pop();
-                }
-                NewGameFocus::Setting(1) => {
-                    state.max_turns_input.pop();
                 }
                 _ => {}
             }
@@ -1219,14 +1216,9 @@ fn handle_new_game_editing(state: &mut NewGameState, key: KeyCode) -> Action {
                         state.players[row].name.push(c);
                     }
                 }
-                NewGameFocus::Setting(0) => {
+                NewGameFocus::Seed => {
                     if c.is_ascii_digit() && state.seed_input.len() < 18 {
                         state.seed_input.push(c);
-                    }
-                }
-                NewGameFocus::Setting(1) => {
-                    if c.is_ascii_digit() && state.max_turns_input.len() < 5 {
-                        state.max_turns_input.push(c);
                     }
                 }
                 _ => {}
@@ -1246,13 +1238,11 @@ fn move_new_game_focus_up(state: &mut NewGameState) {
                 NewGameFocus::Player { row: 0, col }
             }
         }
-        NewGameFocus::Setting(0) => NewGameFocus::Player {
+        NewGameFocus::Seed => NewGameFocus::Player {
             row: state.num_players() - 1,
             col: NewGameCol::Kind,
         },
-        NewGameFocus::Setting(1) => NewGameFocus::Setting(0),
-        NewGameFocus::StartButton => NewGameFocus::Setting(1),
-        _ => state.focus,
+        NewGameFocus::StartButton => NewGameFocus::Seed,
     };
 }
 
@@ -1262,13 +1252,11 @@ fn move_new_game_focus_down(state: &mut NewGameState) {
             if row + 1 < state.num_players() {
                 NewGameFocus::Player { row: row + 1, col }
             } else {
-                NewGameFocus::Setting(0)
+                NewGameFocus::Seed
             }
         }
-        NewGameFocus::Setting(0) => NewGameFocus::Setting(1),
-        NewGameFocus::Setting(1) => NewGameFocus::StartButton,
+        NewGameFocus::Seed => NewGameFocus::StartButton,
         NewGameFocus::StartButton => NewGameFocus::StartButton,
-        _ => state.focus,
     };
 }
 
@@ -1295,11 +1283,14 @@ fn cycle_new_game_value(state: &mut NewGameState, forward: bool) {
         let player = &mut state.players[row];
         match col {
             NewGameCol::Kind => {
-                player.kind = if forward {
-                    player.kind.next()
-                } else {
-                    player.kind.prev()
-                };
+                // Player 0 is always Human; only AI slots (1+) can cycle.
+                if row > 0 {
+                    player.kind = if forward {
+                        player.kind.next_ai()
+                    } else {
+                        player.kind.prev_ai()
+                    };
+                }
             }
             NewGameCol::Model => {
                 if player.kind == PlayerKind::Llm {
@@ -1412,12 +1403,10 @@ fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> S
 
     // Create channel.
     let (tx, rx) = mpsc::unbounded_channel();
-    let max_turns = ng.max_turns();
 
     // Spawn game engine.
     tokio::spawn(async move {
         let mut orchestrator = GameOrchestrator::new(state, players);
-        orchestrator.max_turns = max_turns;
         orchestrator.ui_tx = Some(tx);
 
         let result = orchestrator.run().await;
@@ -1485,7 +1474,6 @@ fn launch_resume(path: &std::path::Path) -> Option<Screen> {
     tokio::spawn(async move {
         let mut orchestrator = GameOrchestrator::new(save.state, players);
         orchestrator.log = log;
-        orchestrator.max_turns = 500;
         orchestrator.ui_tx = Some(tx);
 
         let result = orchestrator.run().await;

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -82,17 +82,19 @@ impl PlayerKind {
         }
     }
 
-    pub fn next(&self) -> Self {
+    /// Cycle to the next AI player kind (Human is excluded for AI slots).
+    pub fn next_ai(&self) -> Self {
         match self {
             PlayerKind::Random => PlayerKind::Llm,
-            PlayerKind::Llm => PlayerKind::Human,
+            PlayerKind::Llm => PlayerKind::Random,
             PlayerKind::Human => PlayerKind::Random,
         }
     }
 
-    pub fn prev(&self) -> Self {
+    /// Cycle to the previous AI player kind (Human is excluded for AI slots).
+    pub fn prev_ai(&self) -> Self {
         match self {
-            PlayerKind::Random => PlayerKind::Human,
+            PlayerKind::Random => PlayerKind::Llm,
             PlayerKind::Llm => PlayerKind::Random,
             PlayerKind::Human => PlayerKind::Llm,
         }
@@ -151,8 +153,8 @@ impl NewGameCol {
 pub enum NewGameFocus {
     /// Player table row + column.
     Player { row: usize, col: NewGameCol },
-    /// Settings: 0 = seed, 1 = max_turns.
-    Setting(usize),
+    /// Seed setting.
+    Seed,
     /// The "Start Game" button.
     StartButton,
 }
@@ -161,7 +163,6 @@ pub enum NewGameFocus {
 pub struct NewGameState {
     pub players: Vec<PlayerConfig>,
     pub seed_input: String,
-    pub max_turns_input: String,
     pub focus: NewGameFocus,
     /// Personality names: built-ins + discovered from TOML.
     pub personality_names: Vec<String>,
@@ -210,7 +211,6 @@ impl NewGameState {
         Self {
             players,
             seed_input: String::new(),
-            max_turns_input: "500".into(),
             focus: NewGameFocus::Player {
                 row: 0,
                 col: NewGameCol::Kind,
@@ -250,10 +250,6 @@ impl NewGameState {
 
     pub fn seed(&self) -> Option<u64> {
         self.seed_input.parse().ok()
-    }
-
-    pub fn max_turns(&self) -> u32 {
-        self.max_turns_input.parse().unwrap_or(500)
     }
 }
 
@@ -498,7 +494,7 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
     f.render_widget(divider, divider_area);
 
     let seed_y = settings_y + 1;
-    let seed_focused = matches!(state.focus, NewGameFocus::Setting(0));
+    let seed_focused = matches!(state.focus, NewGameFocus::Seed);
     let seed_style = cell_style(seed_focused);
     let seed_display = if state.seed_input.is_empty() {
         "random"
@@ -512,18 +508,8 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
     let seed_area = Rect::new(x_start, seed_y, content_width, 1);
     Paragraph::new(seed_line).render(seed_area, f.buffer_mut());
 
-    let turns_y = seed_y + 1;
-    let turns_focused = matches!(state.focus, NewGameFocus::Setting(1));
-    let turns_style = cell_style(turns_focused);
-    let turns_line = Line::from(vec![
-        Span::styled("  Max Turns: ", Style::default().fg(Color::White)),
-        Span::styled(format!("[{}]", state.max_turns_input), turns_style),
-    ]);
-    let turns_area = Rect::new(x_start, turns_y, content_width, 1);
-    Paragraph::new(turns_line).render(turns_area, f.buffer_mut());
-
     // Start button.
-    let button_y = turns_y + 2;
+    let button_y = seed_y + 2;
     let button_focused = matches!(state.focus, NewGameFocus::StartButton);
     let button_style = if button_focused {
         Style::default().fg(Color::Black).bg(Color::Green).bold()

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
@@ -15,9 +15,9 @@ expression: buffer_to_string(&buf)
 
                                                      ────────────────────────────────────────────────────────────────
                                                        Seed: [random]
-                                                       Max Turns: [500]
 
                                                        [ Start Game ]
+
 
 
 


### PR DESCRIPTION
## Description

Simplifies game setup to match the app's core use case: one human player vs AI opponents.

- Removed the "Max Turns" setting from the new game screen and the `--max-turns` CLI flag (the 500-turn safety valve remains as an internal constant in the orchestrator)
- Player 1 is now always Human and cannot be changed
- AI player slots (2-4) cycle only between Random and LLM, never Human
- Updated focus navigation to skip the removed setting row

Fixes #17

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**
All changes were implemented, tested (243 tests pass), and reviewed by Claude Code.

- [x] I am an AI Agent filling out this form (check box if true)