### PR TITLE
docs: fix README to match current CLI and TUI state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # settl
 
 A terminal-based Settlers of Catan game where LLMs play against each other (or you).
-Watch Claude, GPT, and Gemini negotiate trades, form grudges, and compete for longest road — all in your terminal.
+Watch Claude, GPT, and Gemini negotiate trades, form grudges, and compete for longest road -- all in your terminal.
 
 ```
         [Fo 6] [Pa 3] [Hi 8]
@@ -13,26 +13,26 @@ Watch Claude, GPT, and Gemini negotiate trades, form grudges, and compete for lo
 
 ## Features
 
-- **Full base Catan rules** — settlements, cities, roads, robber, development cards, Longest Road, Largest Army, bank trading, player-to-player trading
-- **Multi-provider LLM players** — Claude, GPT, Gemini, and any provider supported by the [genai](https://crates.io/crates/genai) crate
-- **Visible AI reasoning** — every decision comes with a strategic explanation
-- **Personality system** — aggressive traders, grudge holders, cautious builders, chaos agents
-- **TUI spectator mode** — watch AI games with a live hex board, resource panels, and reasoning traces
-- **Game replays** — JSONL event logs and structured JSON replays with full reasoning traces
-- **Save/resume** — save a game in progress and resume later
-- **Reproducible games** — seed the RNG for deterministic board generation
+- **Full base Catan rules** -- settlements, cities, roads, robber, development cards, Longest Road, Largest Army, bank trading, player-to-player trading
+- **Play or spectate** -- player 1 is always human in TUI mode; watch the AI opponents play around you
+- **Multi-provider LLM players** -- Claude, GPT, Gemini, and any provider supported by the [genai](https://crates.io/crates/genai) crate
+- **Visible AI reasoning** -- every decision comes with a strategic explanation
+- **Personality system** -- aggressive traders, grudge holders, cautious builders, chaos agents
+- **Game replays** -- JSONL event logs and structured JSON replays with full reasoning traces
+- **Save/resume** -- save a game in progress and resume later
+- **Reproducible games** -- seed the RNG for deterministic board generation
 
 ## Quick Start
 
 ```bash
-# Run a demo game with random AI players (no API keys needed)
+# Launch the TUI (title screen -> game setup -> play)
+cargo run
+
+# Headless demo with random AI players (no API keys needed)
 cargo run -- --demo
 
-# Run with TUI spectator mode
-cargo run -- --demo --tui
-
-# Run with LLM players (requires API key)
-ANTHROPIC_API_KEY=sk-... cargo run -- --model claude-sonnet-4-6
+# Headless game with LLM players (requires API key)
+ANTHROPIC_API_KEY=sk-... cargo run -- --headless --model claude-sonnet-4-6
 
 # Different models per player
 ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... cargo run -- \
@@ -42,29 +42,69 @@ ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... cargo run -- \
 cargo run -- --demo --seed 42
 ```
 
-## CLI Options
+## Modes
+
+**TUI mode** (default): `cargo run` launches an interactive terminal UI with a title screen, game setup menu, and live hex board. Player 1 is always human; configure AI opponents (Random or LLM) in the setup screen.
+
+**Headless mode**: Activated by passing `--headless`, `--demo`, `--replay`, `--resume`, or `--models`. Runs the game as plain text output, useful for scripting and CI.
+
+## Headless CLI Options
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--headless` | Run in text mode (no TUI) | off |
 | `--demo` | Random AI players, no API keys needed | off |
-| `--tui` | TUI spectator mode with live board | off |
 | `-p, --players N` | Number of players (2-4) | 4 |
 | `-m, --model MODEL` | Default LLM model for all players | claude-sonnet-4-6 |
-| `--models M1,M2,...` | Per-player model assignment | — |
+| `--models M1,M2,...` | Per-player model assignment | -- |
 | `--personality FILE` | TOML personality file | built-in |
-| `--max-turns N` | Turn limit before declaring stuck | 500 |
 | `--seed N` | RNG seed for reproducible boards | random |
-| `--replay FILE` | Replay a saved game (.json or .jsonl) | — |
-| `--resume FILE` | Resume a saved game | — |
+| `--replay FILE` | Replay a saved game (.json or .jsonl) | -- |
+| `--resume FILE` | Resume a saved game | -- |
 
 ## TUI Controls
 
+### During gameplay
+
 | Key | Action |
 |-----|--------|
-| `q` / `Esc` | Quit |
-| `Space` | Pause/unpause |
-| `+` / `-` | Adjust speed |
-| `j` / `k` | Scroll log |
+| `q` / `Esc` | Quit to menu |
+| `Space` | Pause/unpause (spectating) |
+| `+` / `-` | Adjust AI speed |
+| `j` / `k` | Scroll game log |
+| `Tab` | Toggle AI reasoning panel |
+| `?` | Toggle help overlay |
+
+### Action bar (your turn)
+
+| Key | Action |
+|-----|--------|
+| `e` | End Turn |
+| `s` | Build Settlement |
+| `r` | Build Road |
+| `c` | Build City |
+| `d` | Buy Development Card |
+| `t` | Propose Trade |
+| `p` | Play Development Card |
+
+### Trade builder
+
+| Key | Action |
+|-----|--------|
+| `w` `b` `s` `h` `o` | Toggle Wood, Brick, Sheep, Wheat, Ore |
+| `Tab` | Switch between Give / Get sides |
+| `Backspace` | Remove last resource |
+| `Enter` | Confirm trade |
+| `Esc` | Cancel |
+
+### Discard (robber rolled 7)
+
+| Key | Action |
+|-----|--------|
+| `w` `b` `s` `h` `o` | Add resource to discard pile |
+| `Backspace` | Undo last discard |
+| `Enter` | Confirm |
+| `Esc` | Auto-complete remaining discards |
 
 ## Personalities
 
@@ -85,8 +125,8 @@ Built-in personalities: Default Strategist, Aggressive Trader, Grudge Holder, Ca
 
 Games automatically save two replay formats:
 
-- `game_log.jsonl` — one JSON event per line, lightweight
-- `game_replay.json` — structured replay with VP tracking and event descriptions
+- `game_log.jsonl` -- one JSON event per line, lightweight
+- `game_replay.json` -- structured replay with VP tracking and event descriptions
 
 View a replay:
 
@@ -100,7 +140,7 @@ cargo run -- --replay game_log.jsonl
 
 ## Save/Resume
 
-If a game gets stuck (hits max turns), progress is automatically saved to `game_save.json`.
+If a game is interrupted, progress is automatically saved to `game_save.json`.
 Resume with:
 
 ```bash
@@ -111,7 +151,9 @@ cargo run -- --resume game_save.json
 
 ```
 src/
-├── main.rs                    # CLI entry, game setup
+├── main.rs                    # Entry point: TUI vs headless dispatch
+├── headless.rs                # Headless (text-mode) game runner and CLI
+├── lib.rs                     # Crate root, module declarations
 ├── game/
 │   ├── board.rs               # Hex grid (axial coords), terrain, ports
 │   ├── state.rs               # GameState, PlayerState, buildings, roads
@@ -123,9 +165,10 @@ src/
 │   ├── mod.rs                 # Player trait (async)
 │   ├── llm.rs                 # LLM player (genai + tool use)
 │   ├── random.rs              # Random AI player (for testing)
-│   ├── human.rs               # Human player (TUI input)
+│   ├── human.rs               # Human player (raw stdin)
+│   ├── tui_human.rs           # TUI human player (channel-based input)
 │   ├── personality.rs         # Personality system (TOML)
-│   └── prompt.rs              # Board/state → LLM prompt serialization
+│   └── prompt.rs              # Board/state -> LLM prompt serialization
 ├── trading/
 │   ├── negotiation.rs         # Trade protocol, validation, execution
 │   └── offers.rs              # Offer validation, resource checks
@@ -134,7 +177,9 @@ src/
 │   ├── recorder.rs            # GameReplay with state snapshots
 │   └── save.rs                # Save/resume game state
 └── ui/
-    ├── mod.rs                 # TUI app state, event loop
+    ├── mod.rs                 # TUI app state, event loop, input handling
+    ├── screens.rs             # Title, main menu, new game, file picker
+    ├── menu.rs                # Reusable menu widget
     ├── board_view.rs          # Hex board rendering (ratatui)
     ├── resource_bar.rs        # Player resource/VP panel
     ├── chat_panel.rs          # AI reasoning display
@@ -158,8 +203,8 @@ export GOOGLE_API_KEY=...             # Gemini
 # Run all tests
 cargo test
 
-# Run a quick demo game
-cargo run -- --demo --max-turns 100
+# Headless demo game
+cargo run -- --demo
 
 # Run with verbose output
 RUST_LOG=debug cargo run -- --demo


### PR DESCRIPTION
## Description

The README was out of date after the max-turns removal (#24) and TUI-first refactor. This PR brings it in sync with the actual codebase:

- Removes references to `--tui` and `--max-turns` flags (both no longer exist)
- Documents `--headless` mode and explains TUI-default vs headless dispatch
- Expands TUI Controls with action bar shortcuts, trade builder, discard, help overlay
- Updates the architecture tree with new files (`headless.rs`, `lib.rs`, `screens.rs`, `menu.rs`, `tui_human.rs`)
- Replaces emdashes with double dashes per project coding style
- Fixes Save/Resume section (no longer references max turns)
- Updates Features list to reflect human-first TUI design

Fixes #22

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** AI cross-referenced the actual CLI struct in `headless.rs`, TUI input handling in `ui/mod.rs`, and file structure to identify all README inaccuracies.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)