### PR TITLE
fix: use fixed beginner board layout instead of random generation

### DIFF
--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -19,6 +19,7 @@ impl HexCoord {
     }
 
     /// The six neighbours of this hex in axial coordinates.
+    #[allow(dead_code)]
     pub fn neighbors(self) -> [HexCoord; 6] {
         [
             HexCoord::new(self.q + 1, self.r - 1), // NE
@@ -499,6 +500,7 @@ pub fn hex_edges(h: HexCoord) -> [EdgeCoord; 6] {
 // ---------------------------------------------------------------------------
 
 /// Standard Catan terrain distribution (19 tiles).
+#[allow(dead_code)]
 fn standard_terrains() -> Vec<Terrain> {
     vec![
         Terrain::Forest,
@@ -524,11 +526,13 @@ fn standard_terrains() -> Vec<Terrain> {
 }
 
 /// Standard Catan number tokens (18 tokens for 18 non-desert hexes).
+#[allow(dead_code)]
 fn standard_number_tokens() -> Vec<u8> {
     vec![2, 3, 3, 4, 4, 5, 5, 6, 6, 8, 8, 9, 9, 10, 10, 11, 11, 12]
 }
 
 /// Check whether any two adjacent hexes both carry a 6 or 8 token.
+#[allow(dead_code)]
 fn has_adjacent_red_numbers(hexes: &[Hex]) -> bool {
     use std::collections::HashMap;
     let token_map: HashMap<HexCoord, Option<u8>> =
@@ -660,23 +664,29 @@ impl Board {
             .map(|h| h.coord)
     }
 
-    /// Create a deterministic standard Catan board (unshuffled).
+    /// Create the standard Catan beginner board (official 5th Edition layout).
     ///
-    /// Useful for tests and demos.
-    #[allow(dead_code)]
+    /// Desert is in the center at (0,0) with the robber. Terrain and number
+    /// token placement matches the rulebook's "Starting Setup for Beginners."
+    /// No 6/8 tokens are adjacent.
     pub fn default_board() -> Self {
         use Terrain::*;
 
         let coords = board_hex_coords();
 
-        // Standard terrain distribution placed in coordinate order.
+        // Official beginner layout: terrain per hex in coordinate order.
+        //   Row 0 (r=-2): Mountains, Pasture, Forest
+        //   Row 1 (r=-1): Fields, Hills, Pasture, Hills
+        //   Row 2 (r= 0): Forest, Fields, Desert, Forest, Mountains
+        //   Row 3 (r= 1): Forest, Mountains, Fields, Pasture
+        //   Row 4 (r= 2): Hills, Fields, Pasture
         let terrains = vec![
-            Hills, Hills, Hills, Forest, Forest, Forest, Forest, Mountains, Mountains, Mountains,
-            Fields, Fields, Fields, Fields, Pasture, Pasture, Pasture, Pasture, Desert,
+            Mountains, Pasture, Forest, Fields, Hills, Pasture, Hills, Forest, Fields, Desert,
+            Forest, Mountains, Forest, Mountains, Fields, Pasture, Hills, Fields, Pasture,
         ];
 
-        // Standard number tokens in a fixed order.
-        let numbers: Vec<u8> = vec![5, 2, 6, 3, 8, 10, 9, 12, 11, 4, 8, 10, 9, 4, 5, 6, 3, 11];
+        // Number tokens matching the beginner layout (desert gets None).
+        let numbers: Vec<u8> = vec![10, 2, 9, 12, 6, 4, 10, 9, 11, 3, 8, 8, 3, 4, 5, 5, 6, 11];
 
         let mut number_iter = numbers.into_iter();
         let hexes: Vec<Hex> = coords
@@ -704,6 +714,7 @@ impl Board {
     ///
     /// Uses rejection sampling to ensure that 6 and 8 tokens are never placed
     /// on adjacent hexes.
+    #[allow(dead_code)]
     pub fn generate(rng: &mut impl Rng) -> Board {
         let coords = board_hex_coords();
 
@@ -1112,5 +1123,65 @@ mod tests {
         assert_eq!(Terrain::Fields.label(), "Wheat");
         assert_eq!(Terrain::Mountains.label(), "Ore");
         assert_eq!(Terrain::Desert.label(), "Desert");
+    }
+
+    #[test]
+    fn default_board_desert_in_center() {
+        let board = Board::default_board();
+        let desert = board
+            .hexes
+            .iter()
+            .find(|h| h.terrain == Terrain::Desert)
+            .expect("board must have a desert");
+        assert_eq!(
+            desert.coord,
+            HexCoord::new(0, 0),
+            "desert should be at the center"
+        );
+        assert!(desert.number_token.is_none());
+    }
+
+    #[test]
+    fn default_board_correct_distributions() {
+        let board = Board::default_board();
+        assert_eq!(board.hexes.len(), 19);
+
+        let mut forest = 0;
+        let mut hills = 0;
+        let mut pasture = 0;
+        let mut fields = 0;
+        let mut mountains = 0;
+        let mut desert = 0;
+        for hex in &board.hexes {
+            match hex.terrain {
+                Terrain::Forest => forest += 1,
+                Terrain::Hills => hills += 1,
+                Terrain::Pasture => pasture += 1,
+                Terrain::Fields => fields += 1,
+                Terrain::Mountains => mountains += 1,
+                Terrain::Desert => desert += 1,
+            }
+        }
+        assert_eq!(forest, 4);
+        assert_eq!(hills, 3);
+        assert_eq!(pasture, 4);
+        assert_eq!(fields, 4);
+        assert_eq!(mountains, 3);
+        assert_eq!(desert, 1);
+
+        let mut tokens: Vec<u8> = board.hexes.iter().filter_map(|h| h.number_token).collect();
+        tokens.sort();
+        let mut expected = standard_number_tokens();
+        expected.sort();
+        assert_eq!(tokens, expected);
+    }
+
+    #[test]
+    fn default_board_no_adjacent_6_8() {
+        let board = Board::default_board();
+        assert!(
+            !has_adjacent_red_numbers(&board.hexes),
+            "default board must not have adjacent 6/8 tokens"
+        );
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -70,15 +70,8 @@ pub async fn run(cli: HeadlessCli) {
         cli.players
     );
 
-    // Create board.
-    let board = if let Some(seed) = cli.seed {
-        use rand::SeedableRng;
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        game::board::Board::generate(&mut rng)
-    } else {
-        let mut rng = rand::rng();
-        game::board::Board::generate(&mut rng)
-    };
+    // Use the fixed beginner board layout (randomization deferred to a future design).
+    let board = game::board::Board::default_board();
 
     let state = game::state::GameState::new(board.clone(), cli.players);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1326,15 +1326,8 @@ fn launch_game(ng: &NewGameState, discovered_personalities: &[Personality]) -> S
     use std::sync::Arc;
     use tokio::sync::Mutex;
 
-    // Build board.
-    let board = if let Some(seed) = ng.seed() {
-        use rand::SeedableRng;
-        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-        Board::generate(&mut rng)
-    } else {
-        let mut rng = rand::rng();
-        Board::generate(&mut rng)
-    };
+    // Use the fixed beginner board layout (randomization deferred to a future design).
+    let board = Board::default_board();
 
     let state = GameState::new(board, ng.num_players());
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -248,6 +248,7 @@ impl NewGameState {
         }
     }
 
+    #[allow(dead_code)]
     pub fn seed(&self) -> Option<u64> {
         self.seed_input.parse().ok()
     }

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
@@ -9,8 +9,8 @@ expression: buffer_to_string(&buf)
 │                                          *                                   │
 │                                                                              │
 │                                                                              │
-│                              Brick               Brick               Brick   │
-│                                5                   2                   6     │
+│                               Ore                Sheep               Wood    │
+│                               10                   2                   9     │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -18,8 +18,8 @@ expression: buffer_to_string(&buf)
 │            *                                                                 │
 │                                                                              │
 │                                                                              │
-│                    Wood                Wood                Wood              │
-│                      3                   8                  10               │
+│                    Wheat               Brick               Sheep             │
+│                     12                   6                   4               │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                              ◇                   *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
@@ -12,8 +12,8 @@ expression: buffer_to_string(&buf)
 │                                                          *                                       *                                       ││ P2 Charlie 0VP             │
 │                                                                                                                                          ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
-│                                              Brick               Brick               Brick                                               ││ P3 Diana 0VP               │
-│                                                5                   2                   6                                                 ││  W:0 B:0 S:0 H:0 O:0       │
+│                                               Ore                Sheep               Wood                                                ││ P3 Diana 0VP               │
+│                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
@@ -21,8 +21,8 @@ expression: buffer_to_string(&buf)
 │                            *                                                                               *                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wood                Wood                Wood                Wood                                      │└────────────────────────────┘
-│                                      3                   8                  10                   9                                       │┌ Game Log (2/2) ────────────┐
+│                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
+│                                     12                   6                   4                  10                                       │┌ Game Log (2/2) ────────────┐
 │                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
@@ -30,8 +30,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                      *                   ││Tab:AI panel                │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                           Ore                 Ore                 Ore                Wheat               Wheat                           ││                            │
-│                           12                  11                   4                   8                  10                             ││                            │
+│                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
+│                            9                  11                   R                   3                   8                             ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -39,8 +39,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                    Wheat               Wheat               Sheep               Sheep                                     ││                            │
-│                                      9                   4                   5                   6                                       ││                            │
+│                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
+│                                      8                   3                   4                   5                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -48,8 +48,8 @@ expression: buffer_to_string(&buf)
 │                                                                                                  *                                       ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
-│                                              Sheep               Sheep            R Desert                                               ││                            │
-│                                                3                  11                   R                                                 ││                            │
+│                                              Brick               Wheat               Sheep                                               ││                            │
+│                                                5                   6                  11                                                 ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │


### PR DESCRIPTION
## Description

Switch both headless and TUI game modes to use `Board::default_board()` instead of `Board::generate()`. The default board now matches the official Catan 5th Edition "Starting Setup for Beginners" with the desert in the center at (0,0) and proper terrain/number token placement. Board randomization is deferred to a future design.

- Robber correctly starts on the desert hex (already implemented, verified)
- Setup snake-draft and second-settlement resource grants are correct
- No adjacent 6/8 number tokens on the beginner layout

Fixes #18

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:**
Used Claude Code to analyze the board initialization logic, identify that random generation was being used instead of a fixed layout, implement the official beginner board, and update all call sites.

- [x] I am an AI Agent filling out this form (check box if true)