### PR TITLE
docs: add condensed Catan rules for LLM agents

### DIFF
--- a/CATAN_RULES_COMPACT.md
+++ b/CATAN_RULES_COMPACT.md
@@ -1,0 +1,85 @@
+# Catan Rules (Compact)
+
+First to **10 victory points** wins. You can only win on your own turn.
+
+## Resources
+
+| Terrain | Resource | | Terrain | Resource |
+|---------|----------|-|---------|----------|
+| Forest | Lumber | | Fields | Grain |
+| Hills | Brick | | Pasture | Wool |
+| Mountains | Ore | | Desert | None |
+
+## Setup (Snake Draft)
+
+Round 1 (clockwise): each player places 1 settlement + 1 adjacent road.
+Round 2 (reverse order): each player places 1 settlement + 1 adjacent road. You receive 1 resource per hex adjacent to your second settlement.
+
+**Distance rule** (always enforced): no settlement may be placed if any of the 3 adjacent intersections is occupied.
+
+## Turn Phases (in order)
+
+### 1. Roll Dice
+
+- Each hex whose number matches the roll produces resources for adjacent buildings: **1 per settlement, 2 per city**.
+- The robber's hex produces nothing.
+
+### 2. Rolling a 7
+
+1. Every player with **more than 7 cards** discards half (rounded down).
+2. Roller moves the robber to a different hex.
+3. Roller steals 1 random card from an opponent adjacent to the robber's new hex.
+
+### 3. Trade (optional)
+
+**Domestic**: trade any terms with other players. Only the active player may trade. No free gifts, no same-resource swaps.
+
+**Maritime** (with the bank):
+- 4:1 always available
+- 3:1 with a generic harbor
+- 2:1 with a matching special harbor
+
+### 4. Build (optional, as many as you can afford)
+
+| Structure | Cost | VP |
+|-----------|------|----|
+| Road | 1 Brick + 1 Lumber | -- |
+| Settlement | 1 Brick + 1 Lumber + 1 Wool + 1 Grain | 1 |
+| City (upgrade) | 3 Ore + 2 Grain | 2 |
+| Development Card | 1 Ore + 1 Wool + 1 Grain | -- |
+
+**Supply limits**: 15 roads, 5 settlements, 4 cities per player. Upgrading a settlement to a city returns the settlement to your supply.
+
+**Roads** must connect to your existing network (road, settlement, or city).
+**Settlements** must connect to your road network and obey the distance rule.
+**Cities** replace an existing settlement on the same intersection.
+
+## Development Cards
+
+Play at most **1 dev card per turn** (knight or progress), at any point during your turn. You may **not** play a card bought this turn.
+
+| Card | Count | Effect |
+|------|-------|--------|
+| Knight | 14 | Move robber + steal (same as rolling 7, steps 2-3) |
+| Road Building | 2 | Place 2 free roads |
+| Year of Plenty | 2 | Take any 2 resources from the bank |
+| Monopoly | 2 | Name 1 resource; all opponents give you all of that type |
+| Victory Point | 5 | 1 VP each. Keep hidden; reveal only when winning |
+
+## Special Cards
+
+**Longest Road (2 VP)**: first player with a continuous road of 5+ segments. Taken by anyone who builds a strictly longer one. A settlement built on an opponent's road breaks it into two segments.
+
+**Largest Army (2 VP)**: first player to play 3+ knights. Taken by anyone who plays strictly more.
+
+## VP Summary
+
+| Source | VP |
+|--------|----|
+| Settlement | 1 |
+| City | 2 |
+| Longest Road | 2 |
+| Largest Army | 2 |
+| VP dev card | 1 each |
+
+Starting position: 2 settlements = 2 VP. You need 8 more to win.

--- a/src/player/prompt.rs
+++ b/src/player/prompt.rs
@@ -170,23 +170,19 @@ pub fn format_hex_options(hexes: &[HexCoord]) -> String {
         .join("\n")
 }
 
-/// Build a compact system prompt for small/local models (e.g. Bonsai-1.7B).
+/// Condensed Catan rules for LLM system prompts -- everything needed to play
+/// correctly, without component lists, geometry explanations, or tactical tips.
+/// The full rulebook lives in CATAN_RULES.md for human reference.
+const CATAN_RULES: &str = include_str!("../../CATAN_RULES_COMPACT.md");
+
+/// Build the system prompt for an LLM player (e.g. llamafile).
 ///
-/// Uses a condensed rules summary instead of the full rulebook to fit in
-/// limited context windows.
+/// Includes the condensed rulebook from CATAN_RULES_COMPACT.md.
 pub fn system_prompt_compact(player_name: &str, personality_prompt: &str) -> String {
     format!(
         "You are playing Settlers of Catan. Your name is {player_name}.\n\n\
          {personality_prompt}\n\n\
-         RULES:\n\
-         - Build settlements at vertices, roads along edges, upgrade settlements to cities.\n\
-         - Resources: Wood (forest), Brick (hills), Sheep (pasture), Wheat (fields), Ore (mountains).\n\
-         - Costs: Road = Wood+Brick. Settlement = Wood+Brick+Wheat+Sheep. City = 2 Wheat+3 Ore. Dev Card = Wheat+Sheep+Ore.\n\
-         - Roll dice each turn: matching hexes produce resources for adjacent settlements (1) and cities (2).\n\
-         - Roll 7: players with >7 cards discard half, then move robber and steal.\n\
-         - Trade with players or bank (4:1, or 3:1/2:1 with harbors).\n\
-         - Dev cards: Knight (move robber), Road Building (2 free roads), Year of Plenty (2 free resources), Monopoly (take all of 1 type).\n\
-         - Longest Road (5+) and Largest Army (3+ knights) each give 2 VP. First to 10 VP wins.\n\n\
+         {CATAN_RULES}\n\n\
          INSTRUCTIONS:\n\
          - Explain your reasoning, then call the tool to make your choice.\n\
          - Reference coordinates and resource counts.",


### PR DESCRIPTION
## Summary
- Created `CATAN_RULES_COMPACT.md` (~90 lines) -- a condensed version of the full rules doc that includes only what AI agents need to play correctly
- Switched `system_prompt()` in `prompt.rs` to use the compact rules instead of the full 230-line rulebook
- Removed component lists, board geometry, dice probabilities, and tactical tips that don't help LLMs make decisions

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy` and `cargo fmt` pass
- [x] `cargo test` passes (1 pre-existing snapshot failure unrelated to this change)
- [ ] Verify LLM players still play correctly with the condensed rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)