### PR TITLE
fix: collapse duplicate placement actions in action bar

### DIFF
--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -326,6 +326,11 @@ impl GameOrchestrator {
                 PlayerChoice::PlayYearOfPlenty => self.handle_year_of_plenty(player_id).await,
                 PlayerChoice::PlayRoadBuilding => self.handle_road_building(player_id).await,
                 PlayerChoice::ProposeTrade => self.handle_trade(player_id).await,
+                PlayerChoice::BuildRoadIntent => self.handle_build_road(player_id).await,
+                PlayerChoice::BuildSettlementIntent => {
+                    self.handle_build_settlement(player_id).await
+                }
+                PlayerChoice::BuildCityIntent => self.handle_build_city(player_id).await,
             };
 
             match action_result {
@@ -354,11 +359,40 @@ impl GameOrchestrator {
     }
 
     /// Build the list of choices for the current player.
+    ///
+    /// Placement actions (road, settlement, city) are collapsed into single
+    /// intent entries so the action bar shows one item per action type.
+    /// The specific location is collected via board cursor in a follow-up step.
     fn build_choices(&self) -> Vec<PlayerChoice> {
-        let mut choices: Vec<PlayerChoice> = rules::legal_actions(&self.state)
-            .into_iter()
-            .map(PlayerChoice::GameAction)
-            .collect();
+        let actions = rules::legal_actions(&self.state);
+        let mut choices: Vec<PlayerChoice> = Vec::new();
+        let mut has_road = false;
+        let mut has_settlement = false;
+        let mut has_city = false;
+
+        for action in actions {
+            match &action {
+                Action::BuildRoad(_) => {
+                    if !has_road {
+                        choices.push(PlayerChoice::BuildRoadIntent);
+                        has_road = true;
+                    }
+                }
+                Action::BuildSettlement(_) => {
+                    if !has_settlement {
+                        choices.push(PlayerChoice::BuildSettlementIntent);
+                        has_settlement = true;
+                    }
+                }
+                Action::BuildCity(_) => {
+                    if !has_city {
+                        choices.push(PlayerChoice::BuildCityIntent);
+                        has_city = true;
+                    }
+                }
+                _ => choices.push(PlayerChoice::GameAction(action)),
+            }
+        }
 
         // Add dev card intents if the player can play one.
         // Cards bought this turn (last N entries) cannot be played.
@@ -730,6 +764,74 @@ impl GameOrchestrator {
         );
         self.apply_and_log(action, player_id, "Road Building")?;
         Ok(())
+    }
+
+    /// Handle a Build Road intent: show board cursor, then apply the action.
+    async fn handle_build_road(&mut self, player_id: PlayerId) -> Result<(), OrchestratorError> {
+        let legal = rules::legal_road_edges(&self.state, player_id);
+        if legal.is_empty() {
+            return Ok(());
+        }
+        let (idx, reasoning) = self
+            .with_timeout(
+                self.players[player_id].choose_road(
+                    &self.state,
+                    player_id,
+                    &legal,
+                    &self.player_names,
+                ),
+                (0, "timeout fallback".into()),
+            )
+            .await;
+        let edge = legal[idx.min(legal.len() - 1)];
+        self.apply_and_log(Action::BuildRoad(edge), player_id, &reasoning)
+    }
+
+    /// Handle a Build Settlement intent: show board cursor, then apply the action.
+    async fn handle_build_settlement(
+        &mut self,
+        player_id: PlayerId,
+    ) -> Result<(), OrchestratorError> {
+        let legal = rules::legal_settlement_vertices(&self.state, player_id);
+        if legal.is_empty() {
+            return Ok(());
+        }
+        let (idx, reasoning) = self
+            .with_timeout(
+                self.players[player_id].choose_settlement(
+                    &self.state,
+                    player_id,
+                    &legal,
+                    0,
+                    &self.player_names,
+                ),
+                (0, "timeout fallback".into()),
+            )
+            .await;
+        let vertex = legal[idx.min(legal.len() - 1)];
+        self.apply_and_log(Action::BuildSettlement(vertex), player_id, &reasoning)
+    }
+
+    /// Handle a Build City intent: show board cursor, then apply the action.
+    async fn handle_build_city(&mut self, player_id: PlayerId) -> Result<(), OrchestratorError> {
+        let legal = rules::legal_city_vertices(&self.state, player_id);
+        if legal.is_empty() {
+            return Ok(());
+        }
+        let (idx, reasoning) = self
+            .with_timeout(
+                self.players[player_id].choose_settlement(
+                    &self.state,
+                    player_id,
+                    &legal,
+                    0,
+                    &self.player_names,
+                ),
+                (0, "timeout fallback".into()),
+            )
+            .await;
+        let vertex = legal[idx.min(legal.len() - 1)];
+        self.apply_and_log(Action::BuildCity(vertex), player_id, &reasoning)
     }
 
     /// Handle a player proposing a trade: collect offer, broadcast to others, execute if accepted.

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -30,6 +30,12 @@ pub enum PlayerChoice {
     PlayRoadBuilding,
     /// Intent to propose a trade — offer details collected separately.
     ProposeTrade,
+    /// Intent to build a road — edge collected via board cursor.
+    BuildRoadIntent,
+    /// Intent to build a settlement — vertex collected via board cursor.
+    BuildSettlementIntent,
+    /// Intent to build a city — vertex collected via board cursor.
+    BuildCityIntent,
 }
 
 impl PlayerChoice {
@@ -49,6 +55,9 @@ impl PlayerChoice {
             PlayerChoice::PlayYearOfPlenty => "Play Year of Plenty",
             PlayerChoice::PlayRoadBuilding => "Play Road Building",
             PlayerChoice::ProposeTrade => "Propose Trade",
+            PlayerChoice::BuildRoadIntent => "Build Road",
+            PlayerChoice::BuildSettlementIntent => "Build Settlement",
+            PlayerChoice::BuildCityIntent => "Build City",
         }
     }
 
@@ -65,6 +74,9 @@ impl PlayerChoice {
             | PlayerChoice::PlayMonopoly
             | PlayerChoice::PlayYearOfPlenty
             | PlayerChoice::PlayRoadBuilding => Some('p'),
+            PlayerChoice::BuildRoadIntent => Some('r'),
+            PlayerChoice::BuildSettlementIntent => Some('s'),
+            PlayerChoice::BuildCityIntent => Some('c'),
             _ => None,
         }
     }
@@ -95,6 +107,9 @@ impl std::fmt::Display for PlayerChoice {
             PlayerChoice::PlayYearOfPlenty => write!(f, "Play Year of Plenty"),
             PlayerChoice::PlayRoadBuilding => write!(f, "Play Road Building"),
             PlayerChoice::ProposeTrade => write!(f, "Propose Trade"),
+            PlayerChoice::BuildRoadIntent => write!(f, "Build Road"),
+            PlayerChoice::BuildSettlementIntent => write!(f, "Build Settlement"),
+            PlayerChoice::BuildCityIntent => write!(f, "Build City"),
         }
     }
 }

--- a/src/ui/flow_tests.rs
+++ b/src/ui/flow_tests.rs
@@ -271,9 +271,12 @@ async fn setup_phase_completes_with_human_player() {
 
     // The human player (player 0) is at positions 0 and 7 in the snake draft
     // [0,1,2,3,3,2,1,0]. Each position gets a PlaceSettlement + PlaceRoad prompt.
-    // So the human should receive exactly 4 setup prompts.
+    // So the human should receive exactly 4 setup prompts before gameplay begins.
+    // (PlaceRoad also appears during gameplay for build-road intents, so we only
+    // count prompts before the first ChooseAction.)
     let setup_prompts: Vec<&String> = prompt_log
         .iter()
+        .take_while(|p| *p != "ChooseAction")
         .filter(|p| *p == "PlaceSettlement" || *p == "PlaceRoad")
         .collect();
     assert_eq!(


### PR DESCRIPTION
## Summary
- **Bug:** The action bar showed "Build Road [r]" repeated N times (once per legal edge), and similarly for settlements and cities. Pressing `r` only ever selected the first entry.
- **Fix:** Placement actions (road, settlement, city) are now collapsed into single intent entries in the action bar. Selecting one opens a board cursor for location selection -- the same cursor already used during setup and the Road Building dev card.
- **Pattern:** Mirrors the existing dev card intent pattern (PlayKnight, PlayRoadBuilding, etc.) where the action bar shows one entry and a follow-up prompt collects the specifics.

## Test plan
- [x] All 264 existing tests pass
- [x] `cargo clippy` and `cargo fmt` clean
- [x] Snapshot tests unchanged (action bar rendering still works)
- [x] Flow test updated to distinguish setup-phase PlaceRoad prompts from gameplay ones
- [ ] Manual QA: start a game, verify action bar shows one entry per action type, pressing `r`/`s`/`c` opens board cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)