### PR TITLE
fix: remove probability colors and dots from board UI

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,8 +33,7 @@
 | Hex boundary | colored fill only | No border characters, terrain color defines shape |
 | Road (diagonal) | colored block | Player-colored background, 3 cells diagonal |
 | Road (vertical) | colored block | Player-colored background, 5 cells tall |
-| Hex interior | Terrain + number + dots | Each on dedicated row (see template) |
-| Hot numbers (6, 8) | bold + bright white | High probability, must stand out |
+| Hex interior | Terrain + number | Each on dedicated row (see template) |
 
 ### Terrain Labels
 Full resource names displayed on hex tiles (what the terrain produces, not terrain name):
@@ -46,16 +45,6 @@ Full resource names displayed on hex tiles (what the terrain produces, not terra
 | Fields | `Wheat` | Wheat |
 | Mountains | `Ore` | Ore |
 | Desert | `Desert` | Nothing |
-
-### Number Probability Dots
-Display below the number token inside each hex to show roll probability:
-| Numbers | Dots | Probability |
-|---------|------|-------------|
-| 2, 12 | `·` | 1/36 |
-| 3, 11 | `··` | 2/36 |
-| 4, 10 | `···` | 3/36 |
-| 5, 9 | `····` | 4/36 |
-| 6, 8 | `·····` | 5/36 (bold red) |
 
 ## Color System
 
@@ -161,7 +150,7 @@ Pointy-top hexes, interlocking. Each hex cell:
         ╱           ╲         <- cy-2: even wider
       ╱   Wood         ╲      <- cy-1: TERRAIN label (dedicated row)
      ·       6          ·     <- cy:   NUMBER token (dedicated row)
-      ╲    ·····      ╱      <- cy+1: PROBABILITY DOTS (dedicated row)
+      ╲             ╱      <- cy+1: lower fill
         ╲           ╱         <- cy+2: lower diagonals
           ╲       ╱           <- cy+3: narrower diagonals
             ╲   ╱             <- cy+4: closing diagonals

--- a/src/ui/board_view.rs
+++ b/src/ui/board_view.rs
@@ -319,15 +319,8 @@ fn draw_hex_cell(
     }
 
     if let Some(n) = hex.number_token {
-        let is_hot = n == 6 || n == 8;
         let num_str = format!("{:>2}", n);
-        let num_style = if is_hot && is_robber {
-            Style::default().fg(Color::White).bg(fill_bg).bold()
-        } else if is_hot {
-            Style::default().fg(Color::Red).bg(fill_bg).bold()
-        } else {
-            Style::default().fg(fg).bg(fill_bg)
-        };
+        let num_style = Style::default().fg(fg).bg(fill_bg);
         for (i, ch) in num_str.chars().enumerate() {
             set_cell(cx - 1 + i as i16, cy, ch, num_style, area, buf);
         }
@@ -348,23 +341,6 @@ fn draw_hex_cell(
     }
     for dx in -3..=3i16 {
         set_cell(cx + dx, cy + 3, ' ', fill, area, buf);
-    }
-
-    // Probability dots on row cy+1 (per DESIGN.md).
-    if let Some(n) = hex.number_token {
-        let is_hot = n == 6 || n == 8;
-        let dots = board::pip_count(n);
-        if dots > 0 {
-            let dot_style = if is_hot {
-                Style::default().fg(Color::Red).bg(fill_bg).bold()
-            } else {
-                Style::default().fg(Color::DarkGray).bg(fill_bg)
-            };
-            let start = cx - (dots as i16 - 1);
-            for d in 0..dots as i16 {
-                set_cell(start + d * 2, cy + 1, '\u{00b7}', dot_style, area, buf);
-            }
-        }
     }
 }
 

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
@@ -11,7 +11,7 @@ expression: buffer_to_string(&buf)
 │                                                                              │
 │                               Ore                Sheep               Wood    │
 │                               10                   2                   9     │
-│                              · · ·                 ·                · · · ·  │
+│                                                                              │
 │                                                                              │
 │                                                                              │
 │                      *                                                       │
@@ -20,7 +20,7 @@ expression: buffer_to_string(&buf)
 │                                                                              │
 │                    Wheat               Brick               Sheep             │
 │                     12                   6                   4               │
-│                      ·               · · · · ·             · · ·             │
+│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                    ◆                   ◇                                                 ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
@@ -14,7 +14,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                               Ore                Sheep               Wood                                                ││ Diana 0VP                  │
 │                                               10                   2                   9                                                 ││  W:0 B:0 S:0 H:0 O:0       │
-│                                              · · ·                 ·                · · · ·                                              ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││Turn: 1                     │
 │                                                                                                                                          ││Phase: Setup { round:       │
 │                                      *                                                                                                   ││Deck: 25 cards              │
@@ -23,7 +23,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wheat               Brick               Sheep               Brick                                     │└────────────────────────────┘
 │                                     12                   6                   4                  10                                       │┌ Game Log (2) ──────────────┐
-│                                      ·               · · · · ·             · · ·               · · ·                                     ││   1| Game started -- your  │
+│                                                                                                                                          ││   1| Game started -- your  │
 │                                                                                                                                          ││turn will show a prompt     │
 │                                                                                                                                          ││   2| q:quit  Space:pause   │
 │                                                                                                                                          ││j/k:scroll  Tab:AI panel    │
@@ -32,7 +32,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                          Wood                Wheat            R Desert               Wood                 Ore                            ││                            │
 │                            9                  11                   R                   3                   8                             ││                            │
-│                         · · · ·               · ·                                     · ·              · · · · ·                         ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
@@ -41,7 +41,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                    Wood                 Ore                Wheat               Sheep                                     ││                            │
 │                                      8                   3                   4                   5                                       ││                            │
-│                                  · · · · ·              · ·                · · ·              · · · ·                                    ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                            *                                                                               *                             ││                            │
@@ -50,7 +50,7 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                          ││                            │
 │                                              Brick               Wheat               Sheep                                               ││                            │
 │                                                5                   6                  11                                                 ││                            │
-│                                             · · · ·            · · · · ·              · ·                                                ││                            │
+│                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                                                                                                          ││                            │
 │                                                          *                                       *                                       ││                            │


### PR DESCRIPTION
## Description
Remove red highlighting of 6/8 number tokens and probability dot indicators (`·`) below all number tokens on the hex board. This simplifies the board visual by removing unnecessary clutter.

Fixes #47

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**
AI identified all relevant code locations (board_view.rs rendering, DESIGN.md docs) and made the minimal changes needed.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)