### PR TITLE
feat: auto-save game state and add resume from main menu

### DIFF
--- a/src/game/event.rs
+++ b/src/game/event.rs
@@ -2,11 +2,13 @@
 //!
 //! Used for LLM context (recent history) and UI event streaming.
 
+use serde::{Deserialize, Serialize};
+
 use crate::game::actions::{DevCard, PlayerId, TradeOffer};
 use crate::game::board::{EdgeCoord, HexCoord, Resource, VertexCoord};
 
 /// Every discrete game event.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GameEvent {
     // -- Setup --
     InitialSettlementPlaced {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -4,4 +4,5 @@ pub mod dice;
 pub mod event;
 pub mod orchestrator;
 pub mod rules;
+pub mod save;
 pub mod state;

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -53,6 +53,10 @@ pub struct GameOrchestrator {
     pub max_turns: u32,
     /// Optional channel to send UI events to the TUI.
     pub ui_tx: Option<mpsc::UnboundedSender<UiEvent>>,
+    /// Player configs for auto-save (set by the launcher).
+    pub player_configs: Vec<crate::game::save::SavedPlayerConfig>,
+    /// Which llamafile model is in use (for auto-save).
+    pub llamafile_model: crate::llamafile::LlamafileModel,
 }
 
 impl GameOrchestrator {
@@ -65,6 +69,8 @@ impl GameOrchestrator {
             player_names,
             max_turns: 500,
             ui_tx: None,
+            player_configs: Vec::new(),
+            llamafile_model: crate::llamafile::LlamafileModel::default(),
         }
     }
 
@@ -109,6 +115,29 @@ impl GameOrchestrator {
         self.events.push(event);
     }
 
+    /// Write the current game state to the autosave file.
+    fn auto_save(&self) {
+        if self.player_configs.is_empty() {
+            return;
+        }
+        let save = crate::game::save::SaveFile {
+            game_state: self.state.clone(),
+            player_names: self.player_names.clone(),
+            player_configs: self.player_configs.clone(),
+            events: self.events.clone(),
+            llamafile_model: self.llamafile_model,
+            saved_at: {
+                let d = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default();
+                format!("{}", d.as_secs())
+            },
+        };
+        if let Err(e) = crate::game::save::auto_save(&save) {
+            log::warn!("Auto-save failed: {}", e);
+        }
+    }
+
     /// Run the full game and return the winner's PlayerId.
     pub async fn run(&mut self) -> Result<PlayerId, OrchestratorError> {
         // Send initial state so the TUI can render the board before any prompts arrive.
@@ -123,6 +152,7 @@ impl GameOrchestrator {
                 current_player: 0,
                 has_rolled: false,
             };
+            self.auto_save();
         }
 
         // Phase 2: Main game loop.
@@ -146,6 +176,7 @@ impl GameOrchestrator {
                     player: winner,
                     final_vp: vp,
                 });
+                crate::game::save::delete_autosave();
                 if let Some(tx) = &self.ui_tx {
                     let _ = tx.send(UiEvent::GameOver {
                         winner,
@@ -154,6 +185,7 @@ impl GameOrchestrator {
                 }
                 return Ok(winner);
             }
+            self.auto_save();
         }
     }
 

--- a/src/game/save.rs
+++ b/src/game/save.rs
@@ -1,0 +1,158 @@
+//! Auto-save and resume support.
+//!
+//! Saves game state to `~/.settl/saves/autosave.json` after each turn.
+//! The main menu shows a "Continue" option when a save file exists.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::game::event::GameEvent;
+use crate::game::state::GameState;
+use crate::llamafile::LlamafileModel;
+
+/// Serialized player configuration for save/load.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedPlayerConfig {
+    pub name: String,
+    pub is_human: bool,
+    pub personality_index: usize,
+}
+
+/// A complete save file containing everything needed to resume a game.
+#[derive(Serialize, Deserialize)]
+pub struct SaveFile {
+    pub game_state: GameState,
+    pub player_names: Vec<String>,
+    pub player_configs: Vec<SavedPlayerConfig>,
+    pub events: Vec<GameEvent>,
+    pub llamafile_model: LlamafileModel,
+    pub saved_at: String,
+}
+
+fn save_dir() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok().filter(|s| !s.is_empty())?;
+    let dir = PathBuf::from(home).join(".settl").join("saves");
+    let _ = std::fs::create_dir_all(&dir);
+    Some(dir)
+}
+
+fn autosave_path() -> Option<PathBuf> {
+    save_dir().map(|d| d.join("autosave.json"))
+}
+
+/// Write the save file to disk. Returns an error string on failure.
+pub fn auto_save(save: &SaveFile) -> Result<(), String> {
+    let path = autosave_path().ok_or("Could not determine save directory")?;
+    let json = serde_json::to_string(save).map_err(|e| format!("Serialize error: {}", e))?;
+    std::fs::write(&path, json).map_err(|e| format!("Write error: {}", e))
+}
+
+/// Load the autosave file, returning None if it doesn't exist or can't be parsed.
+pub fn load_autosave() -> Option<SaveFile> {
+    let path = autosave_path()?;
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Delete the autosave file (e.g. after game over).
+pub fn delete_autosave() {
+    if let Some(path) = autosave_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Check whether an autosave file exists.
+pub fn has_autosave() -> bool {
+    autosave_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::board::Board;
+
+    /// Use a temp directory instead of ~/.settl/saves for tests.
+    fn save_roundtrip_in_tempdir() -> (SaveFile, SaveFile) {
+        let dir = std::env::temp_dir().join(format!("settl_test_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test_autosave.json");
+
+        let state = GameState::new(Board::default_board(), 3);
+        let save = SaveFile {
+            player_names: vec!["Alice".into(), "Bob".into(), "Charlie".into()],
+            player_configs: vec![
+                SavedPlayerConfig {
+                    name: "Alice".into(),
+                    is_human: true,
+                    personality_index: 0,
+                },
+                SavedPlayerConfig {
+                    name: "Bob".into(),
+                    is_human: false,
+                    personality_index: 1,
+                },
+                SavedPlayerConfig {
+                    name: "Charlie".into(),
+                    is_human: false,
+                    personality_index: 2,
+                },
+            ],
+            events: vec![],
+            llamafile_model: LlamafileModel::default(),
+            game_state: state,
+            saved_at: "2026-04-04T00:00:00Z".into(),
+        };
+
+        let json = serde_json::to_string(&save).expect("serialize");
+        std::fs::write(&path, &json).expect("write");
+        let loaded: SaveFile = serde_json::from_str(&std::fs::read_to_string(&path).expect("read"))
+            .expect("deserialize");
+
+        // Clean up.
+        let _ = std::fs::remove_dir_all(&dir);
+
+        (save, loaded)
+    }
+
+    #[test]
+    fn save_load_roundtrip_preserves_state() {
+        let (original, loaded) = save_roundtrip_in_tempdir();
+
+        assert_eq!(original.player_names, loaded.player_names);
+        assert_eq!(original.player_configs.len(), loaded.player_configs.len());
+        assert_eq!(
+            original.game_state.num_players,
+            loaded.game_state.num_players
+        );
+        assert_eq!(
+            original.game_state.turn_number,
+            loaded.game_state.turn_number
+        );
+        assert_eq!(
+            original.game_state.board.hexes.len(),
+            loaded.game_state.board.hexes.len()
+        );
+        assert_eq!(original.saved_at, loaded.saved_at);
+        assert_eq!(original.llamafile_model, loaded.llamafile_model);
+    }
+
+    #[test]
+    fn save_load_roundtrip_preserves_player_configs() {
+        let (original, loaded) = save_roundtrip_in_tempdir();
+
+        for (orig, load) in original.player_configs.iter().zip(&loaded.player_configs) {
+            assert_eq!(orig.name, load.name);
+            assert_eq!(orig.is_human, load.is_human);
+            assert_eq!(orig.personality_index, load.personality_index);
+        }
+    }
+
+    #[test]
+    fn has_autosave_false_when_no_file() {
+        // With no save file written, has_autosave should return false
+        // (unless a previous test left one, which is unlikely in CI).
+        // We just verify the function doesn't panic.
+        let _ = has_autosave();
+    }
+}

--- a/src/llamafile/download.rs
+++ b/src/llamafile/download.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use super::LlamafileStatus;
 
 /// Which Bonsai model to use for local AI.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum LlamafileModel {
     /// Bonsai-1.7B: fast, small download (~267 MB), limited reasoning output.
     #[default]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -564,6 +564,33 @@ async fn run_event_loop(
                                             saved_config,
                                             task_handle: Some(handle),
                                             process_rx: Some(process_rx),
+                                            resume_save: None,
+                                        };
+                                        app.screen = Screen::LlamafileSetup(setup_state);
+                                    }
+                                }
+                            }
+                            Action::ResumeGame => {
+                                if let Some(save) = crate::game::save::load_autosave() {
+                                    let model = save.llamafile_model;
+                                    if let Some(ref process) = app.llamafile_process {
+                                        let screen = resume_game(
+                                            save,
+                                            &app.personalities,
+                                            Some(process.port),
+                                        );
+                                        app.screen = screen;
+                                    } else {
+                                        let (status_tx, status_rx) = mpsc::unbounded_channel();
+                                        let (handle, process_rx) =
+                                            spawn_llamafile_setup(model, status_tx);
+                                        let setup_state = LlamafileSetupState {
+                                            status: crate::llamafile::LlamafileStatus::Checking,
+                                            status_rx,
+                                            saved_config: NewGameState::new(&app.personalities),
+                                            task_handle: Some(handle),
+                                            process_rx: Some(process_rx),
+                                            resume_save: Some(save),
                                         };
                                         app.screen = Screen::LlamafileSetup(setup_state);
                                     }
@@ -592,11 +619,15 @@ async fn run_event_loop(
                         app.llamafile_process = Some(process);
                     }
                 }
-                // Move saved_config out of the setup state.
+                // Move config out of the setup state and launch/resume.
                 if let Screen::LlamafileSetup(setup) =
                     std::mem::replace(&mut app.screen, Screen::MainMenu(MainMenuState::new()))
                 {
-                    let screen = launch_game(&setup.saved_config, &app.personalities, Some(port));
+                    let screen = if let Some(save) = setup.resume_save {
+                        resume_game(save, &app.personalities, Some(port))
+                    } else {
+                        launch_game(&setup.saved_config, &app.personalities, Some(port))
+                    };
                     app.screen = screen;
                 }
             }
@@ -689,6 +720,7 @@ enum Action {
     Quit,
     Transition(Screen),
     StartGame,
+    ResumeGame,
 }
 
 fn handle_input(app: &mut App, key: KeyCode) -> Action {
@@ -711,6 +743,7 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                 KeyCode::Enter => {
                     let selected_item = items[state.selected];
                     match selected_item {
+                        "Continue" => Action::ResumeGame,
                         "New Game" => Action::Transition(Screen::NewGame(NewGameState::new(
                             &app.personalities,
                         ))),
@@ -761,15 +794,19 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
 
         Screen::LlamafileSetup(_) => match key {
             KeyCode::Esc => {
-                // Cancel setup: abort the background task and return to NewGame.
+                // Cancel setup: abort the background task.
                 if let Screen::LlamafileSetup(mut setup) =
                     std::mem::replace(&mut app.screen, Screen::MainMenu(MainMenuState::new()))
                 {
                     if let Some(handle) = setup.task_handle.take() {
                         handle.abort();
                     }
-                    // Drop the oneshot receiver (cleaned up with the setup state).
-                    Action::Transition(Screen::NewGame(setup.saved_config))
+                    // If resuming, go back to main menu; otherwise back to NewGame.
+                    if setup.resume_save.is_some() {
+                        Action::Transition(Screen::MainMenu(MainMenuState::new()))
+                    } else {
+                        Action::Transition(Screen::NewGame(setup.saved_config))
+                    }
                 } else {
                     Action::Transition(Screen::NewGame(NewGameState::new(&app.personalities)))
                 }
@@ -1344,10 +1381,136 @@ fn launch_game(
 
     let player_names: Vec<String> = active_players.iter().map(|p| p.name.clone()).collect();
 
+    let save_configs: Vec<crate::game::save::SavedPlayerConfig> = active_players
+        .iter()
+        .map(|pc| crate::game::save::SavedPlayerConfig {
+            name: pc.name.clone(),
+            is_human: pc.kind == PlayerKind::Human,
+            personality_index: pc.personality_index,
+        })
+        .collect();
+    let model = ng.llamafile_model;
+
     // Spawn game engine.
     tokio::spawn(async move {
         let mut orchestrator = GameOrchestrator::new(state, players);
         orchestrator.ui_tx = Some(tx);
+        orchestrator.player_configs = save_configs;
+        orchestrator.llamafile_model = model;
+
+        orchestrator.run().await
+    });
+
+    let mut ps = PlayingState::new(rx, player_names, has_human);
+    if let Some((_, prompt_rx, response_tx)) = human_channels {
+        ps.human_prompt_rx = Some(prompt_rx);
+        ps.human_response_tx = Some(response_tx);
+    }
+    Screen::Playing(ps)
+}
+
+/// Resume a saved game, recreating players from the save file.
+fn resume_game(
+    save: crate::game::save::SaveFile,
+    discovered_personalities: &[Personality],
+    llamafile_port: Option<u16>,
+) -> Screen {
+    use player::tui_human::{HumanInputChannel, TuiHumanPlayer};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    let built_in_personalities = [
+        Personality::default_personality(),
+        Personality::aggressive(),
+        Personality::grudge_holder(),
+        Personality::builder(),
+        Personality::chaos_agent(),
+    ];
+
+    let has_human = save.player_configs.iter().any(|p| p.is_human);
+    let human_channels: Option<(
+        Arc<HumanInputChannel>,
+        mpsc::UnboundedReceiver<player::tui_human::HumanPrompt>,
+        mpsc::UnboundedSender<HumanResponse>,
+    )> = if has_human {
+        let (prompt_tx, prompt_rx) = mpsc::unbounded_channel();
+        let (response_tx, response_rx) = mpsc::unbounded_channel::<HumanResponse>();
+        let channel = Arc::new(HumanInputChannel {
+            prompt_tx,
+            response_rx: Mutex::new(response_rx),
+        });
+        Some((channel, prompt_rx, response_tx))
+    } else {
+        None
+    };
+
+    let llama_client = llamafile_port.map(|port| {
+        player::anthropic_client::AnthropicClient::new(
+            format!("http://127.0.0.1:{}", port),
+            "no-key",
+            player::llm_player::LLAMAFILE_MODEL,
+        )
+    });
+
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    let mut players: Vec<Box<dyn player::Player>> = Vec::new();
+    for (slot_id, pc) in save.player_configs.iter().enumerate() {
+        if pc.is_human {
+            let channel = human_channels.as_ref().unwrap().0.clone();
+            players
+                .push(Box::new(TuiHumanPlayer::new(pc.name.clone(), channel))
+                    as Box<dyn player::Player>);
+        } else {
+            let personality = if pc.personality_index < built_in_personalities.len() {
+                built_in_personalities[pc.personality_index].clone()
+            } else {
+                let disc_idx = pc.personality_index - built_in_personalities.len();
+                discovered_personalities
+                    .get(disc_idx)
+                    .cloned()
+                    .unwrap_or_default()
+            };
+            let client = llama_client
+                .clone()
+                .expect("llamafile client should exist when Llamafile players are used");
+            let mut llm = player::llm_player::LlmPlayer::new(
+                pc.name.clone(),
+                client,
+                personality,
+                Some(slot_id),
+            );
+
+            let (reasoning_tx, mut reasoning_rx) = mpsc::unbounded_channel::<String>();
+            llm.set_reasoning_sender(reasoning_tx);
+            let ui_tx_clone = tx.clone();
+            let player_name_clone = pc.name.clone();
+            tokio::spawn(async move {
+                while let Some(chunk) = reasoning_rx.recv().await {
+                    let _ = ui_tx_clone.send(UiEvent::AiReasoningChunk {
+                        player_id: slot_id,
+                        player_name: player_name_clone.clone(),
+                        chunk,
+                    });
+                }
+            });
+
+            players.push(Box::new(llm) as Box<dyn player::Player>);
+        }
+    }
+
+    let player_names = save.player_names.clone();
+    let save_configs = save.player_configs.clone();
+    let model = save.llamafile_model;
+    let events = save.events;
+    let state = save.game_state;
+
+    tokio::spawn(async move {
+        let mut orchestrator = GameOrchestrator::new(state, players);
+        orchestrator.ui_tx = Some(tx);
+        orchestrator.player_configs = save_configs;
+        orchestrator.llamafile_model = model;
+        orchestrator.events = events;
 
         orchestrator.run().await
     });

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -25,15 +25,23 @@ const TITLE_ART: &str = r#"
 #[derive(Debug, Default)]
 pub struct MainMenuState {
     pub selected: usize,
+    pub has_save: bool,
 }
 
 impl MainMenuState {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            selected: 0,
+            has_save: crate::game::save::has_autosave(),
+        }
     }
 
     pub fn menu_items(&self) -> Vec<&'static str> {
-        vec!["New Game", "About", "Quit"]
+        if self.has_save {
+            vec!["Continue", "New Game", "About", "Quit"]
+        } else {
+            vec!["New Game", "About", "Quit"]
+        }
     }
 }
 
@@ -181,6 +189,8 @@ pub struct LlamafileSetupState {
     pub task_handle: Option<tokio::task::JoinHandle<()>>,
     /// Oneshot receiver for the llamafile process once it's ready.
     pub process_rx: Option<tokio::sync::oneshot::Receiver<crate::llamafile::LlamafileProcess>>,
+    /// If set, we are resuming a saved game instead of starting a new one.
+    pub resume_save: Option<crate::game::save::SaveFile>,
 }
 
 impl std::fmt::Debug for LlamafileSetupState {

--- a/src/ui/snapshot_tests.rs
+++ b/src/ui/snapshot_tests.rs
@@ -16,7 +16,10 @@ const HEIGHT: u16 = 65;
 #[test]
 fn snapshot_main_menu() {
     // Use explicit state to avoid filesystem-dependent menu items.
-    let mut app = make_test_app(Screen::MainMenu(MainMenuState { selected: 0 }));
+    let mut app = make_test_app(Screen::MainMenu(MainMenuState {
+        selected: 0,
+        has_save: false,
+    }));
     let buf = render_app_to_buffer(&mut app, WIDTH, HEIGHT);
     insta::assert_snapshot!("main_menu", buffer_to_string(&buf));
 }
@@ -42,7 +45,10 @@ fn snapshot_post_game() {
 #[test]
 fn snapshot_size_warning() {
     // Render at a small size so the warning popup appears.
-    let mut app = make_test_app(Screen::MainMenu(MainMenuState { selected: 0 }));
+    let mut app = make_test_app(Screen::MainMenu(MainMenuState {
+        selected: 0,
+        has_save: false,
+    }));
     app.show_size_warning = true;
     let buf = render_app_to_buffer(&mut app, 80, 24);
     insta::assert_snapshot!("size_warning", buffer_to_string(&buf));

--- a/src/ui/testing.rs
+++ b/src/ui/testing.rs
@@ -204,6 +204,7 @@ pub fn llamafile_setup_app() -> App {
         saved_config: NewGameState::new(&[]),
         task_handle: None,
         process_rx: None,
+        resume_save: None,
     };
     make_test_app(Screen::LlamafileSetup(setup))
 }


### PR DESCRIPTION
## Description

Implements auto-save and resume functionality. The game auto-saves to `~/.settl/saves/autosave.json` after setup completes and after each turn. The main menu shows a "Continue" option when a save file exists, which loads the saved game state and recreates players (human and AI) from the saved configuration. The save file is deleted on game over.

Key changes:
- New `src/game/save.rs` module with `SaveFile`/`SavedPlayerConfig` types and save/load/delete functions
- `GameEvent` and `LlamafileModel` now derive `Serialize`/`Deserialize`
- Orchestrator auto-saves after setup and each turn, deletes save on game over
- Main menu dynamically shows "Continue" when a save file exists
- `resume_game()` function recreates players from saved config and restores game state
- LlamafileSetup screen handles both new game and resume flows

Fixes #54

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Planned and implemented save/load module, orchestrator hooks, and UI resume flow.

- [x] I am an AI Agent filling out this form (check box if true)