### PR TITLE
feat: update desert terrain color for better distinction

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -56,7 +56,7 @@ Full resource names displayed on hex tiles (what the terrain produces, not terra
 | Pasture | Bright green | `Color::Rgb(80, 180, 60)` |
 | Fields | Golden yellow | `Color::Rgb(200, 170, 50)` |
 | Mountains | Cool gray | `Color::Rgb(140, 140, 150)` |
-| Desert | Sandy tan | `Color::Rgb(180, 160, 120)` |
+| Desert | Warm sand | `Color::Rgb(205, 175, 115)` |
 
 **Fallback (256-color terminals):** Forest=Green, Hills=Red, Pasture=LightGreen, Fields=Yellow, Mountains=Gray, Desert=DarkGray.
 

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -211,7 +211,7 @@ impl Terrain {
             Terrain::Pasture => (80, 180, 60),
             Terrain::Fields => (200, 170, 50),
             Terrain::Mountains => (140, 140, 150),
-            Terrain::Desert => (180, 160, 120),
+            Terrain::Desert => (205, 175, 115),
         }
     }
 }

--- a/src/ui/board_view.rs
+++ b/src/ui/board_view.rs
@@ -30,7 +30,7 @@ fn terrain_color(t: Terrain) -> Color {
         Terrain::Pasture => Color::Rgb(80, 180, 60),
         Terrain::Fields => Color::Rgb(200, 170, 50),
         Terrain::Mountains => Color::Rgb(140, 140, 150),
-        Terrain::Desert => Color::Rgb(180, 160, 120),
+        Terrain::Desert => Color::Rgb(205, 175, 115),
     }
 }
 


### PR DESCRIPTION
## Description

Update desert terrain color from `RGB(180, 160, 120)` (sandy tan) to `RGB(205, 175, 115)` (warm sand).

The old desert color was too close to Fields in hue (~40° vs ~48°) and brightness, making them hard to distinguish at a glance on the hex board. The new color shifts warmer/amber (~37°) with moderate saturation (45% vs Fields' 75%), creating a clear "dusty sand" vs "vivid gold" contrast while staying distinct from Hills (much lighter) and Mountains (warm vs cool).

Fixes #62

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)