### PR TITLE
feat: move Start Game to top of new game screen

### DIFF
--- a/src/ui/flow_tests.rs
+++ b/src/ui/flow_tests.rs
@@ -206,20 +206,13 @@ fn screen_navigation_menu_to_newgame_and_back() {
 fn screen_navigation_new_game_configure_and_start() {
     let mut app = new_game_app();
 
-    // Navigate down to the start button.
-    // Default focus is PlayerCount.
-    // Down x7: PlayerCount -> P2 -> P3 -> P4 -> FriendlyRobber -> BoardLayout -> AiModel -> StartButton.
-    for _ in 0..7 {
-        handle_input(&mut app, KeyCode::Down);
-    }
-
+    // Default focus is StartButton -- Enter immediately starts the game.
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.focus, NewGameFocus::StartButton);
     } else {
         panic!("should still be on NewGame");
     }
 
-    // Enter on StartButton triggers StartGame action.
     let action = handle_input(&mut app, KeyCode::Enter);
     assert!(
         matches!(action, Action::StartGame),

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -93,13 +93,14 @@ fn new_game_esc_returns_to_main_menu() {
 #[test]
 fn new_game_player_count_toggle() {
     let mut app = new_game_app();
-    // Default is 4 players. Focus starts on PlayerCount.
+    // Default is 4 players. Focus starts on StartButton.
     if let Screen::NewGame(ref state) = app.screen {
-        assert_eq!(state.focus, NewGameFocus::PlayerCount);
+        assert_eq!(state.focus, NewGameFocus::StartButton);
         assert!(state.four_players);
         assert_eq!(state.num_players(), 4);
     }
-    // Toggle to 3 players.
+    // Move down to PlayerCount, then toggle to 3 players.
+    handle_input(&mut app, KeyCode::Down);
     handle_input(&mut app, KeyCode::Right);
     if let Screen::NewGame(ref state) = app.screen {
         assert!(!state.four_players);
@@ -116,12 +117,20 @@ fn new_game_player_count_toggle() {
 #[test]
 fn new_game_focus_navigation() {
     let mut app = new_game_app();
-    // Start on PlayerCount. Down should go to Player { row: 1 }.
+    // Start on StartButton. Down should go to PlayerCount.
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.focus, NewGameFocus::StartButton);
+    }
+    handle_input(&mut app, KeyCode::Down);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.focus, NewGameFocus::PlayerCount);
+    }
+    // Down to Player { row: 1 }.
     handle_input(&mut app, KeyCode::Down);
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.focus, NewGameFocus::Player { row: 1 });
     }
-    // Down again to Player { row: 2 }.
+    // Down to Player { row: 2 }.
     handle_input(&mut app, KeyCode::Down);
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.focus, NewGameFocus::Player { row: 2 });
@@ -146,17 +155,13 @@ fn new_game_focus_navigation() {
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.focus, NewGameFocus::AiModel);
     }
-    // Down to StartButton.
-    handle_input(&mut app, KeyCode::Down);
-    if let Screen::NewGame(ref state) = app.screen {
-        assert_eq!(state.focus, NewGameFocus::StartButton);
-    }
 }
 
 #[test]
 fn new_game_focus_skips_player_4_in_3_player_mode() {
     let mut app = new_game_app();
-    // Toggle to 3-player mode.
+    // Move to PlayerCount and toggle to 3-player mode.
+    handle_input(&mut app, KeyCode::Down);
     handle_input(&mut app, KeyCode::Right);
     // Navigate: PlayerCount -> Player 2 -> Player 3 -> FriendlyRobber (skip Player 4).
     handle_input(&mut app, KeyCode::Down);
@@ -276,6 +281,30 @@ fn new_game_model_toggle() {
     handle_input(&mut app, KeyCode::Right);
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.model_index, 0);
+    }
+}
+
+#[test]
+fn new_game_enter_starts_game_from_any_focus() {
+    // Enter should trigger StartGame regardless of which row is focused.
+    for focus in &[
+        NewGameFocus::StartButton,
+        NewGameFocus::PlayerCount,
+        NewGameFocus::Player { row: 1 },
+        NewGameFocus::FriendlyRobber,
+        NewGameFocus::BoardLayout,
+        NewGameFocus::AiModel,
+    ] {
+        let mut app = new_game_app();
+        if let Screen::NewGame(ref mut state) = app.screen {
+            state.focus = *focus;
+        }
+        let action = handle_input(&mut app, KeyCode::Enter);
+        assert!(
+            matches!(action, Action::StartGame),
+            "Enter on {:?} should trigger StartGame",
+            focus,
+        );
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -833,13 +833,7 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                 cycle_new_game_value(state, true);
                 Action::None
             }
-            KeyCode::Enter => match state.focus {
-                NewGameFocus::StartButton => Action::StartGame,
-                _ => {
-                    cycle_new_game_value(state, true);
-                    Action::None
-                }
-            },
+            KeyCode::Enter => Action::StartGame,
             _ => Action::None,
         },
 
@@ -1260,7 +1254,7 @@ fn find_nearest_in_direction(
 
 /// Ordered list of focusable rows, skipping player 4 when in 3-player mode.
 fn focusable_rows(state: &NewGameState) -> Vec<NewGameFocus> {
-    let mut rows = vec![NewGameFocus::PlayerCount];
+    let mut rows = vec![NewGameFocus::StartButton, NewGameFocus::PlayerCount];
     // AI player rows: indices 1, 2, 3 (skip index 3 in 3-player mode).
     for i in 1..4 {
         if i == 3 && !state.four_players {
@@ -1271,7 +1265,6 @@ fn focusable_rows(state: &NewGameState) -> Vec<NewGameFocus> {
     rows.push(NewGameFocus::FriendlyRobber);
     rows.push(NewGameFocus::BoardLayout);
     rows.push(NewGameFocus::AiModel);
-    rows.push(NewGameFocus::StartButton);
     rows
 }
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -147,7 +147,7 @@ impl NewGameState {
 
         Self {
             players,
-            focus: NewGameFocus::PlayerCount,
+            focus: NewGameFocus::StartButton,
             personality_names,
             four_players: true,
             friendly_robber: false,
@@ -552,8 +552,20 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
         .style(Style::default().fg(Color::Yellow).bold());
     f.render_widget(title, title_area);
 
+    // Start button (at top for quick launch).
+    let button_y = area.y + 3;
+    let button_focused = matches!(state.focus, NewGameFocus::StartButton);
+    let button_style = if button_focused {
+        Style::default().fg(Color::Black).bg(Color::Green).bold()
+    } else {
+        Style::default().fg(Color::Green).bold()
+    };
+    let button_area = Rect::new(x_start, button_y, content_width, 1);
+    let button = Paragraph::new("  [ Start Game ]").style(button_style);
+    f.render_widget(button, button_area);
+
     // -- PLAYERS section --
-    let section_y = area.y + 3;
+    let section_y = button_y + 2;
     let section_area = Rect::new(x_start, section_y, content_width, 1);
     let section = Paragraph::new("PLAYERS").style(Style::default().fg(Color::DarkGray).bold());
     f.render_widget(section, section_area);
@@ -696,23 +708,11 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
         ms_focused,
     );
 
-    // Start button.
-    let button_y = ms_y + 2;
-    let button_focused = matches!(state.focus, NewGameFocus::StartButton);
-    let button_style = if button_focused {
-        Style::default().fg(Color::Black).bg(Color::Green).bold()
-    } else {
-        Style::default().fg(Color::Green).bold()
-    };
-    let button_area = Rect::new(x_start, button_y, content_width, 1);
-    let button = Paragraph::new("  [ Start Game ]").style(button_style);
-    f.render_widget(button, button_area);
-
     // Hint bar at bottom.
     let hint_y = area.y + area.height - 1;
     let hint_area = Rect::new(area.x, hint_y, area.width, 1);
     let hint = Paragraph::new(
-        "\u{2191}\u{2193}: move  |  \u{2190}\u{2192}: change  |  Enter: select  |  Esc: back",
+        "\u{2191}\u{2193}: move  |  \u{2190}\u{2192}: change  |  Enter: start  |  Esc: back",
     )
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
@@ -5,6 +5,8 @@ expression: buffer_to_string(&buf)
 
                                                                                  New Game
 
+                                                       [ Start Game ]
+
                                                      PLAYERS
 
                                                          Players:  ○ 3   ● 4
@@ -20,7 +22,6 @@ expression: buffer_to_string(&buf)
                                                           Board Layout        Beginner
                                                           AI Model            Bonsai 1.7B (fast)
 
-                                                       [ Start Game ]
 
 
 
@@ -65,5 +66,4 @@ expression: buffer_to_string(&buf)
 
 
 
-
-                                                          ↑↓: move  |  ←→: change  |  Enter: select  |  Esc: back
+                                                          ↑↓: move  |  ←→: change  |  Enter: start  |  Esc: back

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game_llamafile.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game_llamafile.snap
@@ -5,6 +5,8 @@ expression: buffer_to_string(&buf)
 
                                                                                  New Game
 
+                                                       [ Start Game ]
+
                                                      PLAYERS
 
                                                          Players:  ○ 3   ● 4
@@ -20,7 +22,6 @@ expression: buffer_to_string(&buf)
                                                           Board Layout        Beginner
                                                           AI Model            Bonsai 1.7B (fast)
 
-                                                       [ Start Game ]
 
 
 
@@ -65,5 +66,4 @@ expression: buffer_to_string(&buf)
 
 
 
-
-                                                          ↑↓: move  |  ←→: change  |  Enter: select  |  Esc: back
+                                                          ↑↓: move  |  ←→: change  |  Enter: start  |  Esc: back


### PR DESCRIPTION
## Description

Moves the "Start Game" button to the top of the new game screen (first focusable item) so users can launch with defaults immediately by pressing Enter. Enter now starts the game from any focus position.

Fixes #61

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)