### PR TITLE
feat: add Anthropic API as AI backend

### DIFF
--- a/src/anthropic_api.rs
+++ b/src/anthropic_api.rs
@@ -1,0 +1,131 @@
+//! Anthropic API model discovery.
+//!
+//! Detects the `ANTHROPIC_API_KEY` environment variable, verifies the key
+//! against the Anthropic API, and fetches the list of available models.
+
+use crate::config::{ModelBackend, ModelEntry};
+
+const ANTHROPIC_BASE_URL: &str = "https://api.anthropic.com";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// A model returned by the Anthropic list models API.
+#[derive(Debug, Clone)]
+pub struct AnthropicModel {
+    pub id: String,
+    pub display_name: String,
+}
+
+/// Check for `ANTHROPIC_API_KEY` in the environment.
+pub fn detect_api_key() -> Option<String> {
+    std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Fetch available models from the Anthropic API.
+/// Returns the models sorted by recency (API default).
+pub async fn list_models(api_key: &str) -> Result<Vec<AnthropicModel>, String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(5))
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+
+    let url = format!("{ANTHROPIC_BASE_URL}/v1/models?limit=100");
+    let resp = client
+        .get(&url)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("API returned {status}: {body}"));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("JSON parse error: {e}"))?;
+
+    let data = body
+        .get("data")
+        .and_then(|v| v.as_array())
+        .ok_or("Missing 'data' array in response")?;
+
+    let models: Vec<AnthropicModel> = data
+        .iter()
+        .filter_map(|entry| {
+            let id = entry.get("id")?.as_str()?;
+            let display_name = entry.get("display_name")?.as_str()?;
+            Some(AnthropicModel {
+                id: id.to_string(),
+                display_name: display_name.to_string(),
+            })
+        })
+        .collect();
+
+    Ok(models)
+}
+
+/// Convert discovered Anthropic models into config entries.
+pub fn to_model_entries(api_key: &str, models: &[AnthropicModel]) -> Vec<ModelEntry> {
+    models
+        .iter()
+        .map(|m| ModelEntry {
+            name: m.display_name.clone(),
+            backend: ModelBackend::Api {
+                base_url: ANTHROPIC_BASE_URL.to_string(),
+                api_key: api_key.to_string(),
+                model: m.id.clone(),
+            },
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_api_key_reads_env() {
+        // This test just verifies the function doesn't panic.
+        // Actual env var presence depends on the environment.
+        let _ = detect_api_key();
+    }
+
+    #[test]
+    fn to_model_entries_converts_correctly() {
+        let models = vec![
+            AnthropicModel {
+                id: "claude-sonnet-4-20250514".into(),
+                display_name: "Claude Sonnet 4".into(),
+            },
+            AnthropicModel {
+                id: "claude-opus-4-20250514".into(),
+                display_name: "Claude Opus 4".into(),
+            },
+        ];
+
+        let entries = to_model_entries("sk-test-key", &models);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "Claude Sonnet 4");
+        assert_eq!(entries[1].name, "Claude Opus 4");
+
+        match &entries[0].backend {
+            ModelBackend::Api {
+                base_url,
+                api_key,
+                model,
+            } => {
+                assert_eq!(base_url, "https://api.anthropic.com");
+                assert_eq!(api_key, "sk-test-key");
+                assert_eq!(model, "claude-sonnet-4-20250514");
+            }
+            _ => panic!("Expected Api backend"),
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,6 +69,30 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    /// Merge auto-discovered Anthropic API models into the registry.
+    ///
+    /// Adds new models and updates existing ones (matched by model ID).
+    /// Discovered models are ephemeral -- they are not persisted to disk.
+    pub fn merge_anthropic_models(&mut self, entries: Vec<ModelEntry>) {
+        for entry in entries {
+            let model_id = match &entry.backend {
+                ModelBackend::Api { model, .. } => model.clone(),
+                _ => continue,
+            };
+            // Update if a model with the same API model ID already exists.
+            if let Some(existing) = self.models.iter_mut().find(
+                |m| matches!(&m.backend, ModelBackend::Api { model, .. } if *model == model_id),
+            ) {
+                existing.name = entry.name;
+                existing.backend = entry.backend;
+            } else {
+                self.models.push(entry);
+            }
+        }
+    }
+}
+
 /// Return the path to `~/.settl/config.toml`.
 pub fn config_path() -> PathBuf {
     let home = std::env::var("HOME")
@@ -159,5 +183,72 @@ mod tests {
             }
             _ => panic!("Expected Api backend"),
         }
+    }
+
+    #[test]
+    fn merge_anthropic_models_adds_new() {
+        let mut config = Config::default();
+        assert_eq!(config.models.len(), 2);
+
+        let entries = vec![ModelEntry {
+            name: "Claude Sonnet 4".into(),
+            backend: ModelBackend::Api {
+                base_url: "https://api.anthropic.com".into(),
+                api_key: "sk-test".into(),
+                model: "claude-sonnet-4-20250514".into(),
+            },
+        }];
+        config.merge_anthropic_models(entries);
+        assert_eq!(config.models.len(), 3);
+        assert_eq!(config.models[2].name, "Claude Sonnet 4");
+    }
+
+    #[test]
+    fn merge_anthropic_models_updates_existing() {
+        let mut config = Config {
+            models: vec![ModelEntry {
+                name: "Old Name".into(),
+                backend: ModelBackend::Api {
+                    base_url: "https://api.anthropic.com".into(),
+                    api_key: "sk-old".into(),
+                    model: "claude-sonnet-4-20250514".into(),
+                },
+            }],
+        };
+
+        let entries = vec![ModelEntry {
+            name: "Claude Sonnet 4".into(),
+            backend: ModelBackend::Api {
+                base_url: "https://api.anthropic.com".into(),
+                api_key: "sk-new".into(),
+                model: "claude-sonnet-4-20250514".into(),
+            },
+        }];
+        config.merge_anthropic_models(entries);
+
+        // Should update, not duplicate.
+        assert_eq!(config.models.len(), 1);
+        assert_eq!(config.models[0].name, "Claude Sonnet 4");
+        match &config.models[0].backend {
+            ModelBackend::Api { api_key, .. } => assert_eq!(api_key, "sk-new"),
+            _ => panic!("Expected Api backend"),
+        }
+    }
+
+    #[test]
+    fn merge_anthropic_models_ignores_llamafile_entries() {
+        let mut config = Config::default();
+        let initial_count = config.models.len();
+
+        // Passing a llamafile entry should be ignored.
+        let entries = vec![ModelEntry {
+            name: "Not an API model".into(),
+            backend: ModelBackend::Llamafile {
+                url: "https://example.com".into(),
+                filename: "test.llamafile".into(),
+            },
+        }];
+        config.merge_anthropic_models(entries);
+        assert_eq!(config.models.len(), initial_count);
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -26,6 +26,11 @@ pub struct HeadlessCli {
     /// Run in headless mode (no TUI)
     #[arg(long)]
     pub headless: bool,
+
+    /// Model name from the registry to use (e.g. "Claude Sonnet 4").
+    /// If not set, uses a local llamafile.
+    #[arg(long)]
+    pub model: Option<String>,
 }
 
 pub async fn run(cli: HeadlessCli) {
@@ -40,14 +45,8 @@ pub async fn run(cli: HeadlessCli) {
 
     let state = game::state::GameState::new(board.clone(), cli.players);
 
-    // Start local llamafile AI server.
-    // Keep `_process` alive so the llamafile is killed when this function returns.
-    let (port, _process) = setup_llamafile_headless().await;
-    let client = player::anthropic_client::AnthropicClient::new(
-        format!("http://127.0.0.1:{}", port),
-        "no-key",
-        player::llm_player::LLAMAFILE_MODEL,
-    );
+    // Resolve the AI client: either from --model (API) or local llamafile.
+    let (client, _llamafile_process) = setup_ai_client(&cli).await;
 
     let custom_personality = cli.personality.as_ref().map(|path| {
         player::personality::Personality::from_toml_file(std::path::Path::new(path)).unwrap_or_else(
@@ -84,7 +83,7 @@ pub async fn run(cli: HeadlessCli) {
     println!("settl - Terminal Edition with LLM Players");
     println!("==========================================\n");
     println!("{}\n", player::prompt::ascii_board(&board));
-    println!("Starting game with local AI (Bonsai-8B)...\n");
+    println!("Starting game with {} players...\n", cli.players);
 
     let mut orchestrator = game::orchestrator::GameOrchestrator::new(state, players);
 
@@ -106,6 +105,82 @@ pub async fn run(cli: HeadlessCli) {
             eprintln!("Game ended: {}", e);
         }
     }
+}
+
+/// Set up the AI client based on CLI args.
+///
+/// If `--model` is given, looks up the model in the config registry (including
+/// auto-discovered Anthropic models). Otherwise, falls back to local llamafile.
+///
+/// Returns the client and an optional llamafile process handle (caller must keep
+/// it alive to prevent the process from being killed).
+async fn setup_ai_client(
+    cli: &HeadlessCli,
+) -> (
+    Arc<player::anthropic_client::AnthropicClient>,
+    Option<crate::llamafile::LlamafileProcess>,
+) {
+    let mut config = crate::config::load_config();
+
+    // Discover Anthropic models if API key is set.
+    if let Some(api_key) = crate::anthropic_api::detect_api_key() {
+        match crate::anthropic_api::list_models(&api_key).await {
+            Ok(models) => {
+                let entries = crate::anthropic_api::to_model_entries(&api_key, &models);
+                eprintln!("Discovered {} Anthropic model(s)", entries.len());
+                config.merge_anthropic_models(entries);
+            }
+            Err(e) => {
+                eprintln!("Warning: Failed to fetch Anthropic models: {e}");
+            }
+        }
+    }
+
+    if let Some(ref model_name) = cli.model {
+        // Find the model in the registry by name (case-insensitive substring match).
+        let entry = config
+            .models
+            .iter()
+            .find(|m| m.name.to_lowercase().contains(&model_name.to_lowercase()));
+
+        match entry {
+            Some(crate::config::ModelEntry {
+                name,
+                backend:
+                    crate::config::ModelBackend::Api {
+                        base_url,
+                        api_key,
+                        model,
+                    },
+            }) => {
+                eprintln!("Using API model: {name}");
+                let client =
+                    player::anthropic_client::AnthropicClient::new(base_url, api_key, model);
+                return (client, None);
+            }
+            Some(entry) => {
+                eprintln!(
+                    "Warning: Model '{}' is a llamafile, not an API model. Falling back to llamafile.",
+                    entry.name
+                );
+            }
+            None => {
+                let available: Vec<&str> = config.models.iter().map(|m| m.name.as_str()).collect();
+                eprintln!("Error: Model '{model_name}' not found in registry.");
+                eprintln!("Available models: {}", available.join(", "));
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Fallback: start local llamafile.
+    let (port, process) = setup_llamafile_headless().await;
+    let client = player::anthropic_client::AnthropicClient::new(
+        format!("http://127.0.0.1:{}", port),
+        "no-key",
+        player::llm_player::LLAMAFILE_MODEL,
+    );
+    (client, Some(process))
 }
 
 /// Download (if needed) and start a local llamafile, printing progress to stderr.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod anthropic_api;
 pub mod config;
 pub mod game;
 pub mod headless;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -495,7 +495,21 @@ pub async fn run_app() -> io::Result<()> {
     let size = terminal.size()?;
     let show_size_warning = size.width < MIN_TERM_WIDTH || size.height < MIN_TERM_HEIGHT;
 
-    let config = crate::config::load_config();
+    let mut config = crate::config::load_config();
+
+    // Discover Anthropic models if API key is set.
+    if let Some(api_key) = crate::anthropic_api::detect_api_key() {
+        match crate::anthropic_api::list_models(&api_key).await {
+            Ok(models) => {
+                let entries = crate::anthropic_api::to_model_entries(&api_key, &models);
+                log::info!("Discovered {} Anthropic model(s)", entries.len());
+                config.merge_anthropic_models(entries);
+            }
+            Err(e) => {
+                log::warn!("Failed to fetch Anthropic models: {e}");
+            }
+        }
+    }
 
     let mut app = App {
         screen: Screen::MainMenu(MainMenuState::new()),


### PR DESCRIPTION
## Description

Adds support for using Claude models via the Anthropic API as AI players. On startup, if `ANTHROPIC_API_KEY` is set, the app verifies the key and fetches available models via the list models API. Discovered models appear in the model picker on the new game screen alongside local llamafile options.

Headless mode now supports `--model` flag to select an API model by name:
```bash
cargo run -- --headless --model "Claude Sonnet 4"
```

Fixes #64

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)