### PR TITLE
feat: make reasoning effort configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,16 +39,30 @@ pub enum ModelBackend {
     },
 }
 
+/// Valid effort levels for the Anthropic Messages API.
+pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "max"];
+
+/// Default effort level index (points to "low" in EFFORT_LEVELS).
+pub const DEFAULT_EFFORT_INDEX: usize = 0;
+
 /// Top-level application config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Registered AI models.
     pub models: Vec<ModelEntry>,
+    /// Default reasoning effort level for AI players.
+    #[serde(default = "default_effort")]
+    pub default_effort: String,
+}
+
+pub fn default_effort() -> String {
+    EFFORT_LEVELS[DEFAULT_EFFORT_INDEX].to_string()
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
+            default_effort: default_effort(),
             models: vec![
                 ModelEntry {
                     name: "Bonsai 1.7B (fast)".into(),
@@ -113,6 +127,7 @@ mod tests {
     #[test]
     fn roundtrip_toml() {
         let config = Config {
+            default_effort: default_effort(),
             models: vec![
                 ModelEntry {
                     name: "Test Llamafile".into(),

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -26,6 +26,10 @@ pub struct HeadlessCli {
     /// Run in headless mode (no TUI)
     #[arg(long)]
     pub headless: bool,
+
+    /// Reasoning effort level: low, medium, high, max
+    #[arg(long, default_value = "low")]
+    pub effort: String,
 }
 
 pub async fn run(cli: HeadlessCli) {
@@ -71,12 +75,14 @@ pub async fn run(cli: HeadlessCli) {
             let personality = custom_personality
                 .clone()
                 .unwrap_or_else(|| default_personalities[i % default_personalities.len()].clone());
-            Box::new(player::llm_player::LlmPlayer::new(
+            let mut llm = player::llm_player::LlmPlayer::new(
                 name_list[i].into(),
                 Arc::clone(&client),
                 personality,
                 Some(i),
-            )) as Box<dyn player::Player>
+            );
+            llm.set_effort(cli.effort.clone());
+            Box::new(llm) as Box<dyn player::Player>
         })
         .collect();
 

--- a/src/player/anthropic_client.rs
+++ b/src/player/anthropic_client.rs
@@ -26,6 +26,9 @@ pub struct MessagesRequest {
     pub tools: Vec<ToolDef>,
     /// Enable streaming (SSE) responses.
     pub stream: bool,
+    /// Output configuration (effort level).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<OutputConfig>,
     // -- llamafile extensions (omitted when None) --
     /// Assign this request to a specific KV cache slot.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -33,6 +36,12 @@ pub struct MessagesRequest {
     /// Reuse the KV cache from a previous request in this slot.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_prompt: Option<bool>,
+}
+
+/// Output configuration for controlling reasoning effort.
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputConfig {
+    pub effort: String,
 }
 
 impl MessagesRequest {
@@ -44,6 +53,7 @@ impl MessagesRequest {
             messages: Vec::new(),
             tools: Vec::new(),
             stream: false,
+            output_config: None,
             id_slot: None,
             cache_prompt: None,
         }

--- a/src/player/llm_player.rs
+++ b/src/player/llm_player.rs
@@ -94,6 +94,8 @@ pub struct LlmPlayer {
     extra_context: tokio::sync::Mutex<String>,
     /// Optional channel to stream reasoning text chunks to the UI in real-time.
     reasoning_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    /// Reasoning effort level (e.g. "low", "medium", "high", "max").
+    effort: Option<String>,
 }
 
 impl LlmPlayer {
@@ -114,7 +116,13 @@ impl LlmPlayer {
             conversation: tokio::sync::Mutex::new(Conversation::new(system_prompt)),
             extra_context: tokio::sync::Mutex::new(String::new()),
             reasoning_tx: None,
+            effort: None,
         }
+    }
+
+    /// Set the reasoning effort level (e.g. "low", "medium", "high", "max").
+    pub fn set_effort(&mut self, effort: String) {
+        self.effort = Some(effort);
     }
 
     /// Set the streaming reasoning sender. Called before the game starts.
@@ -293,6 +301,11 @@ impl LlmPlayer {
             request.id_slot = self.slot_id;
             request.cache_prompt = Some(true);
             request.stream = self.reasoning_tx.is_some();
+            if let Some(ref effort) = self.effort {
+                request.output_config = Some(crate::player::anthropic_client::OutputConfig {
+                    effort: effort.clone(),
+                });
+            }
 
             // On retry, notify the UI that we're retrying.
             if attempt > 0 {

--- a/src/ui/flow_tests.rs
+++ b/src/ui/flow_tests.rs
@@ -208,8 +208,8 @@ fn screen_navigation_new_game_configure_and_start() {
 
     // Navigate down to the start button.
     // Default focus is PlayerCount.
-    // Down x7: PlayerCount -> P2 -> P3 -> P4 -> FriendlyRobber -> BoardLayout -> AiModel -> StartButton.
-    for _ in 0..7 {
+    // Down x8: PlayerCount -> P2 -> P3 -> P4 -> FriendlyRobber -> BoardLayout -> AiModel -> ReasoningEffort -> StartButton.
+    for _ in 0..8 {
         handle_input(&mut app, KeyCode::Down);
     }
 

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -146,6 +146,11 @@ fn new_game_focus_navigation() {
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.focus, NewGameFocus::AiModel);
     }
+    // Down to ReasoningEffort.
+    handle_input(&mut app, KeyCode::Down);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.focus, NewGameFocus::ReasoningEffort);
+    }
     // Down to StartButton.
     handle_input(&mut app, KeyCode::Down);
     if let Screen::NewGame(ref state) = app.screen {
@@ -276,6 +281,53 @@ fn new_game_model_toggle() {
     handle_input(&mut app, KeyCode::Right);
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.model_index, 0);
+    }
+}
+
+#[test]
+fn new_game_reasoning_effort_toggle() {
+    let mut app = new_game_app();
+    if let Screen::NewGame(ref mut state) = app.screen {
+        state.focus = NewGameFocus::ReasoningEffort;
+    }
+    // Default effort is "low" (index 0).
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, crate::config::DEFAULT_EFFORT_INDEX);
+        assert_eq!(state.effort_index, 0);
+    }
+    // Cycle forward: low -> medium.
+    handle_input(&mut app, KeyCode::Right);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 1);
+    }
+    // Cycle forward: medium -> high.
+    handle_input(&mut app, KeyCode::Right);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 2);
+    }
+    // Cycle backward: high -> medium.
+    handle_input(&mut app, KeyCode::Left);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 1);
+    }
+}
+
+#[test]
+fn new_game_reasoning_effort_updates_all_players() {
+    let mut app = new_game_app();
+    if let Screen::NewGame(ref mut state) = app.screen {
+        state.focus = NewGameFocus::ReasoningEffort;
+    }
+    // Cycle to "medium" (index 1).
+    handle_input(&mut app, KeyCode::Right); // low -> medium
+    if let Screen::NewGame(ref state) = app.screen {
+        // All AI players should have effort_index 1.
+        for player in &state.players[1..] {
+            assert_eq!(
+                player.effort_index, 1,
+                "AI player should have medium effort"
+            );
+        }
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1271,6 +1271,7 @@ fn focusable_rows(state: &NewGameState) -> Vec<NewGameFocus> {
     rows.push(NewGameFocus::FriendlyRobber);
     rows.push(NewGameFocus::BoardLayout);
     rows.push(NewGameFocus::AiModel);
+    rows.push(NewGameFocus::ReasoningEffort);
     rows.push(NewGameFocus::StartButton);
     rows
 }
@@ -1325,6 +1326,20 @@ fn cycle_new_game_value(state: &mut NewGameState, forward: bool) {
                         .checked_sub(1)
                         .unwrap_or(state.model_names.len() - 1)
                 };
+            }
+        }
+        NewGameFocus::ReasoningEffort => {
+            let n = crate::config::EFFORT_LEVELS.len();
+            state.effort_index = if forward {
+                (state.effort_index + 1) % n
+            } else {
+                state.effort_index.checked_sub(1).unwrap_or(n - 1)
+            };
+            // Update all AI players to the new effort level.
+            for player in &mut state.players {
+                if player.kind == PlayerKind::Llamafile {
+                    player.effort_index = state.effort_index;
+                }
             }
         }
         NewGameFocus::StartButton => {}
@@ -1408,6 +1423,11 @@ fn launch_game(
                     personality,
                     Some(slot_id),
                 );
+
+                // Set reasoning effort from per-player config.
+                if let Some(effort) = crate::config::EFFORT_LEVELS.get(pc.effort_index) {
+                    llm.set_effort(effort.to_string());
+                }
 
                 // Set up streaming reasoning bridge: LlmPlayer -> String chunks -> UiEvent.
                 let (reasoning_tx, mut reasoning_rx) = mpsc::unbounded_channel::<String>();
@@ -1727,6 +1747,7 @@ fn clone_new_game_state(ng: &NewGameState) -> NewGameState {
         random_board: ng.random_board,
         model_index: ng.model_index,
         model_names: ng.model_names.clone(),
+        effort_index: ng.effort_index,
     }
 }
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -68,6 +68,8 @@ pub struct PlayerConfig {
     pub name: String,
     pub kind: PlayerKind,
     pub personality_index: usize,
+    /// Reasoning effort index into `config::EFFORT_LEVELS`.
+    pub effort_index: usize,
 }
 
 const DEFAULT_NAMES: &[&str] = &["Marco", "Leif", "Vasco"];
@@ -85,6 +87,8 @@ pub enum NewGameFocus {
     BoardLayout,
     /// AI Model Size toggle.
     AiModel,
+    /// Reasoning effort level toggle.
+    ReasoningEffort,
     /// The "Start Game" button.
     StartButton,
 }
@@ -105,6 +109,8 @@ pub struct NewGameState {
     pub model_index: usize,
     /// Cached model display names from the config.
     pub model_names: Vec<String>,
+    /// Reasoning effort index into `config::EFFORT_LEVELS`.
+    pub effort_index: usize,
 }
 
 impl NewGameState {
@@ -122,6 +128,11 @@ impl NewGameState {
 
         let model_names: Vec<String> = config.models.iter().map(|m| m.name.clone()).collect();
 
+        let effort_index = crate::config::EFFORT_LEVELS
+            .iter()
+            .position(|&e| e == config.default_effort)
+            .unwrap_or(crate::config::DEFAULT_EFFORT_INDEX);
+
         let username = std::env::var("USER")
             .ok()
             .filter(|s| !s.is_empty())
@@ -134,12 +145,14 @@ impl NewGameState {
                         name: username.clone(),
                         kind: PlayerKind::Human,
                         personality_index: 0,
+                        effort_index,
                     }
                 } else {
                     PlayerConfig {
                         name: DEFAULT_NAMES[i - 1].into(),
                         kind: PlayerKind::Llamafile,
                         personality_index: i.min(personality_names.len().saturating_sub(1)),
+                        effort_index,
                     }
                 }
             })
@@ -154,6 +167,7 @@ impl NewGameState {
             random_board: false,
             model_index: 0,
             model_names,
+            effort_index,
         }
     }
 
@@ -365,6 +379,7 @@ impl SettingsState {
     pub fn save(&self) -> Config {
         let config = Config {
             models: self.models.clone(),
+            default_effort: crate::config::default_effort(),
         };
         let _ = crate::config::save_config(&config);
         config
@@ -696,8 +711,25 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
         ms_focused,
     );
 
+    // Reasoning Effort.
+    let re_y = ms_y + 1;
+    let re_focused = matches!(state.focus, NewGameFocus::ReasoningEffort);
+    let re_value = crate::config::EFFORT_LEVELS
+        .get(state.effort_index)
+        .copied()
+        .unwrap_or("high");
+    draw_toggle_row(
+        f,
+        x_start,
+        re_y,
+        content_width,
+        "Reasoning Effort",
+        re_value,
+        re_focused,
+    );
+
     // Start button.
-    let button_y = ms_y + 2;
+    let button_y = re_y + 2;
     let button_focused = matches!(state.focus, NewGameFocus::StartButton);
     let button_style = if button_focused {
         Style::default().fg(Color::Black).bg(Color::Green).bold()

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
@@ -19,9 +19,9 @@ expression: buffer_to_string(&buf)
                                                           Friendly Robber     Off
                                                           Board Layout        Beginner
                                                           AI Model            Bonsai 1.7B (fast)
+                                                          Reasoning Effort    low
 
                                                        [ Start Game ]
-
 
 
 

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game_llamafile.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game_llamafile.snap
@@ -19,9 +19,9 @@ expression: buffer_to_string(&buf)
                                                           Friendly Robber     Off
                                                           Board Layout        Beginner
                                                           AI Model            Bonsai 1.7B (fast)
+                                                          Reasoning Effort    low
 
                                                        [ Start Game ]
-
 
 
 


### PR DESCRIPTION
## Description

Adds reasoning effort as a configurable parameter for AI players. The effort level controls the Anthropic API's `output_config.effort` field (low/medium/high/max).

- Global default stored in `~/.settl/config.toml` (defaults to "low" for fast games)
- Configurable on the new game screen via "Reasoning Effort" toggle in RULES section
- Changing the global toggle updates all AI players
- Headless mode: `cargo run -- --headless --effort high`

Fixes #59

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)