### PR TITLE
feat: add event hook system for external integrations

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,16 +39,29 @@ pub enum ModelBackend {
     },
 }
 
+/// A hook that runs a shell command when a game event fires.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookConfig {
+    /// Event name to match (e.g. "DiceRolled", "GameWon") or "*" for all events.
+    pub event: String,
+    /// Shell command to execute. Event data is piped as JSON to stdin.
+    pub command: String,
+}
+
 /// Top-level application config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Registered AI models.
     pub models: Vec<ModelEntry>,
+    /// Event hooks -- shell commands triggered by game events.
+    #[serde(default)]
+    pub hooks: Vec<HookConfig>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
+            hooks: Vec::new(),
             models: vec![
                 ModelEntry {
                     name: "Bonsai 1.7B (fast)".into(),
@@ -113,6 +126,10 @@ mod tests {
     #[test]
     fn roundtrip_toml() {
         let config = Config {
+            hooks: vec![HookConfig {
+                event: "GameWon".into(),
+                command: "echo win".into(),
+            }],
             models: vec![
                 ModelEntry {
                     name: "Test Llamafile".into(),
@@ -159,5 +176,9 @@ mod tests {
             }
             _ => panic!("Expected Api backend"),
         }
+
+        assert_eq!(parsed.hooks.len(), 1);
+        assert_eq!(parsed.hooks[0].event, "GameWon");
+        assert_eq!(parsed.hooks[0].command, "echo win");
     }
 }

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -48,6 +48,8 @@ pub struct GameOrchestrator {
     /// Event history for LLM context.
     pub events: Vec<GameEvent>,
     /// Player names, indexed by PlayerId.
+    /// Event hooks -- shell commands triggered by game events.
+    pub hooks: Vec<crate::config::HookConfig>,
     pub player_names: Vec<String>,
     /// Maximum turns before declaring the game stuck (safety valve).
     pub max_turns: u32,
@@ -67,6 +69,7 @@ impl GameOrchestrator {
             players,
             events: Vec::new(),
             player_names,
+            hooks: Vec::new(),
             max_turns: 500,
             ui_tx: None,
             player_configs: Vec::new(),
@@ -110,8 +113,9 @@ impl GameOrchestrator {
         }
     }
 
-    /// Record a game event for LLM history context.
+    /// Record a game event for LLM history context and fire hooks.
     fn record_event(&mut self, event: GameEvent) {
+        crate::hooks::fire(&self.hooks, &event, &self.player_names);
         self.events.push(event);
     }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -86,7 +86,9 @@ pub async fn run(cli: HeadlessCli) {
     println!("{}\n", player::prompt::ascii_board(&board));
     println!("Starting game with local AI (Bonsai-8B)...\n");
 
+    let config = crate::config::load_config();
     let mut orchestrator = game::orchestrator::GameOrchestrator::new(state, players);
+    orchestrator.hooks = config.hooks;
 
     match orchestrator.run().await {
         Ok(_winner) => {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,256 @@
+//! Event hook system -- runs shell commands when game events fire.
+//!
+//! Hooks are configured in `~/.settl/config.toml`:
+//! ```toml
+//! [[hooks]]
+//! event = "GameWon"
+//! command = "curl -X POST localhost:8080/event"
+//!
+//! [[hooks]]
+//! event = "*"
+//! command = "cat >> /tmp/settl-events.jsonl"
+//! ```
+//!
+//! When a matching event fires, the command is spawned as a child process
+//! with the event serialized as JSON on stdin. Hooks are fire-and-forget:
+//! they run asynchronously and never block the game.
+
+use crate::config::HookConfig;
+use crate::game::event::GameEvent;
+
+/// Determine the event name string for a `GameEvent` variant (e.g. "DiceRolled").
+fn event_name(event: &GameEvent) -> &'static str {
+    match event {
+        GameEvent::InitialSettlementPlaced { .. } => "InitialSettlementPlaced",
+        GameEvent::InitialRoadPlaced { .. } => "InitialRoadPlaced",
+        GameEvent::DiceRolled { .. } => "DiceRolled",
+        GameEvent::ResourcesDistributed { .. } => "ResourcesDistributed",
+        GameEvent::SettlementBuilt { .. } => "SettlementBuilt",
+        GameEvent::CityUpgraded { .. } => "CityUpgraded",
+        GameEvent::RoadBuilt { .. } => "RoadBuilt",
+        GameEvent::TradeProposed { .. } => "TradeProposed",
+        GameEvent::TradeAccepted { .. } => "TradeAccepted",
+        GameEvent::TradeRejected { .. } => "TradeRejected",
+        GameEvent::TradeCountered { .. } => "TradeCountered",
+        GameEvent::TradeWithdrawn { .. } => "TradeWithdrawn",
+        GameEvent::BankTradeExecuted { .. } => "BankTradeExecuted",
+        GameEvent::DevCardBought { .. } => "DevCardBought",
+        GameEvent::DevCardPlayed { .. } => "DevCardPlayed",
+        GameEvent::RobberMoved { .. } => "RobberMoved",
+        GameEvent::CardsDiscarded { .. } => "CardsDiscarded",
+        GameEvent::GameWon { .. } => "GameWon",
+    }
+}
+
+/// Fire all matching hooks for a game event.
+///
+/// Hooks run as background tasks (fire-and-forget). The event is serialized
+/// to JSON and piped to each matching command's stdin.
+pub fn fire(hooks: &[HookConfig], event: &GameEvent, player_names: &[String]) {
+    if hooks.is_empty() {
+        return;
+    }
+
+    let name = event_name(event);
+
+    // Build JSON payload: { "event": "<name>", "data": <event>, "player_names": [...] }
+    let payload = match serde_json::to_string(&serde_json::json!({
+        "event": name,
+        "data": event,
+        "player_names": player_names,
+    })) {
+        Ok(json) => json,
+        Err(e) => {
+            log::warn!("Failed to serialize hook event: {e}");
+            return;
+        }
+    };
+
+    for hook in hooks {
+        if hook.event != "*" && hook.event != name {
+            continue;
+        }
+
+        let command = hook.command.clone();
+        let payload = payload.clone();
+
+        // Fire-and-forget: spawn in a background task.
+        tokio::spawn(async move {
+            match run_hook_command(&command, &payload).await {
+                Ok(()) => {}
+                Err(e) => {
+                    log::warn!("Hook command failed: {command}: {e}");
+                }
+            }
+        });
+    }
+}
+
+/// Run a single hook command with the payload on stdin.
+async fn run_hook_command(command: &str, payload: &str) -> Result<(), String> {
+    use tokio::process::Command;
+
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("spawn: {e}"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        let _ = stdin.write_all(payload.as_bytes()).await;
+        let _ = stdin.write_all(b"\n").await;
+        // Drop stdin to close it, signaling EOF to the child.
+    }
+
+    // Don't wait for the child -- fire and forget.
+    // The tokio runtime will reap it when it exits.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HookConfig;
+
+    #[test]
+    fn event_name_covers_all_variants() {
+        // Verify every variant has a name by constructing one of each.
+        let events = vec![
+            GameEvent::InitialSettlementPlaced {
+                player: 0,
+                vertex: dummy_vertex(),
+            },
+            GameEvent::InitialRoadPlaced {
+                player: 0,
+                edge: dummy_edge(),
+            },
+            GameEvent::DiceRolled {
+                player: 0,
+                values: (3, 4),
+                total: 7,
+            },
+            GameEvent::ResourcesDistributed {
+                distributions: vec![],
+            },
+            GameEvent::SettlementBuilt {
+                player: 0,
+                vertex: dummy_vertex(),
+                reasoning: String::new(),
+            },
+            GameEvent::CityUpgraded {
+                player: 0,
+                vertex: dummy_vertex(),
+                reasoning: String::new(),
+            },
+            GameEvent::RoadBuilt {
+                player: 0,
+                edge: dummy_edge(),
+                reasoning: String::new(),
+            },
+            GameEvent::TradeProposed {
+                from: 0,
+                offer: dummy_offer(),
+                reasoning: String::new(),
+            },
+            GameEvent::TradeAccepted {
+                by: 0,
+                reasoning: String::new(),
+            },
+            GameEvent::TradeRejected {
+                by: 0,
+                reasoning: String::new(),
+            },
+            GameEvent::TradeCountered {
+                by: 0,
+                counter_offer: dummy_offer(),
+                reasoning: String::new(),
+            },
+            GameEvent::TradeWithdrawn { by: 0 },
+            GameEvent::BankTradeExecuted {
+                player: 0,
+                gave: (crate::game::board::Resource::Wood, 4),
+                got: (crate::game::board::Resource::Brick, 1),
+            },
+            GameEvent::DevCardBought { player: 0 },
+            GameEvent::DevCardPlayed {
+                player: 0,
+                card: crate::game::actions::DevCard::Knight,
+                reasoning: String::new(),
+            },
+            GameEvent::RobberMoved {
+                player: 0,
+                to: crate::game::board::HexCoord { q: 0, r: 0 },
+                stole_from: None,
+            },
+            GameEvent::CardsDiscarded {
+                player: 0,
+                cards: vec![],
+            },
+            GameEvent::GameWon {
+                player: 0,
+                final_vp: 10,
+            },
+        ];
+
+        let names: Vec<&str> = events.iter().map(event_name).collect();
+        assert_eq!(names.len(), 18);
+        // All names should be non-empty and unique.
+        for name in &names {
+            assert!(!name.is_empty());
+        }
+        let unique: std::collections::HashSet<&&str> = names.iter().collect();
+        assert_eq!(unique.len(), 18, "all event names should be unique");
+    }
+
+    #[test]
+    fn fire_skips_non_matching_hooks() {
+        // This just verifies fire() doesn't panic with no matches.
+        let hooks = vec![HookConfig {
+            event: "GameWon".into(),
+            command: "echo test".into(),
+        }];
+        let event = GameEvent::DiceRolled {
+            player: 0,
+            values: (3, 4),
+            total: 7,
+        };
+        fire(&hooks, &event, &["Alice".into()]);
+    }
+
+    #[test]
+    fn fire_with_empty_hooks_is_noop() {
+        let event = GameEvent::DiceRolled {
+            player: 0,
+            values: (3, 4),
+            total: 7,
+        };
+        fire(&[], &event, &["Alice".into()]);
+    }
+
+    fn dummy_vertex() -> crate::game::board::VertexCoord {
+        crate::game::board::VertexCoord {
+            hex: crate::game::board::HexCoord { q: 0, r: 0 },
+            dir: crate::game::board::VertexDirection::North,
+        }
+    }
+
+    fn dummy_edge() -> crate::game::board::EdgeCoord {
+        crate::game::board::EdgeCoord {
+            hex: crate::game::board::HexCoord { q: 0, r: 0 },
+            dir: crate::game::board::EdgeDirection::NorthEast,
+        }
+    }
+
+    fn dummy_offer() -> crate::game::actions::TradeOffer {
+        crate::game::actions::TradeOffer {
+            from: 0,
+            offering: vec![],
+            requesting: vec![],
+            message: String::new(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod game;
 pub mod headless;
+pub mod hooks;
 pub mod llamafile;
 pub mod logging;
 pub mod player;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1451,9 +1451,11 @@ fn launch_game(
         .unwrap_or_default();
 
     // Spawn game engine.
+    let hooks = config.hooks.clone();
     tokio::spawn(async move {
         let mut orchestrator = GameOrchestrator::new(state, players);
         orchestrator.ui_tx = Some(tx);
+        orchestrator.hooks = hooks;
         orchestrator.player_configs = save_configs;
         orchestrator.model_name = model_name;
 
@@ -1561,9 +1563,11 @@ fn resume_game(
     let events = save.events;
     let state = save.game_state;
 
+    let hooks = config.hooks.clone();
     tokio::spawn(async move {
         let mut orchestrator = GameOrchestrator::new(state, players);
         orchestrator.ui_tx = Some(tx);
+        orchestrator.hooks = hooks;
         orchestrator.player_configs = save_configs;
         orchestrator.model_name = model_name;
         orchestrator.events = events;

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -365,6 +365,7 @@ impl SettingsState {
     pub fn save(&self) -> Config {
         let config = Config {
             models: self.models.clone(),
+            hooks: Vec::new(),
         };
         let _ = crate::config::save_config(&config);
         config


### PR DESCRIPTION
## Description

Adds a shell command hook system triggered by game events, enabling external integrations like aoe (agent-of-empires). Hooks are configured in `~/.settl/config.toml`:

```toml
[[hooks]]
event = "*"
command = "cat >> /tmp/settl-events.jsonl"

[[hooks]]
event = "GameWon"
command = "curl -X POST localhost:8080/settl-event"
```

When a game event fires, matching hooks spawn as background processes with JSON on stdin:
```json
{"event":"DiceRolled","data":{"DiceRolled":{"player":0,"values":[3,4],"total":7}},"player_names":["Alice","Bob"]}
```

All 18 `GameEvent` variants are supported. Hooks are fire-and-forget (never block the game). Input control via tmux send-keys (no custom IPC needed).

Fixes #2

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)