### PR TITLE
feat: make reasoning effort configurable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,12 @@ pub enum ModelBackend {
     },
 }
 
+/// Valid effort levels for the Anthropic Messages API.
+pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "max"];
+
+/// Default effort level index (points to "low" in EFFORT_LEVELS).
+pub const DEFAULT_EFFORT_INDEX: usize = 0;
+
 /// A hook that runs a shell command when a game event fires.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookConfig {
@@ -56,12 +62,20 @@ pub struct Config {
     /// Event hooks -- shell commands triggered by game events.
     #[serde(default)]
     pub hooks: Vec<HookConfig>,
+    /// Default reasoning effort level for AI players.
+    #[serde(default = "default_effort")]
+    pub default_effort: String,
+}
+
+pub fn default_effort() -> String {
+    EFFORT_LEVELS[DEFAULT_EFFORT_INDEX].to_string()
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             hooks: Vec::new(),
+            default_effort: default_effort(),
             models: vec![
                 ModelEntry {
                     name: "Bonsai 1.7B (fast)".into(),
@@ -154,6 +168,7 @@ mod tests {
                 event: "GameWon".into(),
                 command: "echo win".into(),
             }],
+            default_effort: default_effort(),
             models: vec![
                 ModelEntry {
                     name: "Test Llamafile".into(),
@@ -227,6 +242,8 @@ mod tests {
     #[test]
     fn merge_anthropic_models_updates_existing() {
         let mut config = Config {
+            hooks: Vec::new(),
+            default_effort: default_effort(),
             models: vec![ModelEntry {
                 name: "Old Name".into(),
                 backend: ModelBackend::Api {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -31,6 +31,10 @@ pub struct HeadlessCli {
     /// If not set, uses a local llamafile.
     #[arg(long)]
     pub model: Option<String>,
+
+    /// Reasoning effort level: low, medium, high, or max.
+    #[arg(long, default_value = "low")]
+    pub effort: String,
 }
 
 pub async fn run(cli: HeadlessCli) {
@@ -70,12 +74,14 @@ pub async fn run(cli: HeadlessCli) {
             let personality = custom_personality
                 .clone()
                 .unwrap_or_else(|| default_personalities[i % default_personalities.len()].clone());
-            Box::new(player::llm_player::LlmPlayer::new(
+            let mut llm = player::llm_player::LlmPlayer::new(
                 name_list[i].into(),
                 Arc::clone(&client),
                 personality,
                 Some(i),
-            )) as Box<dyn player::Player>
+            );
+            llm.set_effort(cli.effort.clone());
+            Box::new(llm) as Box<dyn player::Player>
         })
         .collect();
 

--- a/src/player/anthropic_client.rs
+++ b/src/player/anthropic_client.rs
@@ -26,6 +26,9 @@ pub struct MessagesRequest {
     pub tools: Vec<ToolDef>,
     /// Enable streaming (SSE) responses.
     pub stream: bool,
+    /// Output configuration (e.g. reasoning effort level).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<OutputConfig>,
     // -- llamafile extensions (omitted when None) --
     /// Assign this request to a specific KV cache slot.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -44,10 +47,17 @@ impl MessagesRequest {
             messages: Vec::new(),
             tools: Vec::new(),
             stream: false,
+            output_config: None,
             id_slot: None,
             cache_prompt: None,
         }
     }
+}
+
+/// Output configuration for controlling reasoning effort.
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputConfig {
+    pub effort: String,
 }
 
 /// A single message in the conversation.

--- a/src/player/llm_player.rs
+++ b/src/player/llm_player.rs
@@ -94,6 +94,8 @@ pub struct LlmPlayer {
     extra_context: tokio::sync::Mutex<String>,
     /// Optional channel to stream reasoning text chunks to the UI in real-time.
     reasoning_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    /// Optional reasoning effort level (e.g. "low", "medium", "high", "max").
+    effort: Option<String>,
 }
 
 impl LlmPlayer {
@@ -114,12 +116,18 @@ impl LlmPlayer {
             conversation: tokio::sync::Mutex::new(Conversation::new(system_prompt)),
             extra_context: tokio::sync::Mutex::new(String::new()),
             reasoning_tx: None,
+            effort: None,
         }
     }
 
     /// Set the streaming reasoning sender. Called before the game starts.
     pub fn set_reasoning_sender(&mut self, tx: tokio::sync::mpsc::UnboundedSender<String>) {
         self.reasoning_tx = Some(tx);
+    }
+
+    /// Set the reasoning effort level. Called before the game starts.
+    pub fn set_effort(&mut self, effort: String) {
+        self.effort = Some(effort);
     }
 
     // -- Tool definitions (same schemas as before, new ToolDef type) --
@@ -293,6 +301,11 @@ impl LlmPlayer {
             request.id_slot = self.slot_id;
             request.cache_prompt = Some(true);
             request.stream = self.reasoning_tx.is_some();
+            if let Some(ref effort) = self.effort {
+                request.output_config = Some(crate::player::anthropic_client::OutputConfig {
+                    effort: effort.clone(),
+                });
+            }
 
             // On retry, notify the UI that we're retrying.
             if attempt > 0 {

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -155,6 +155,61 @@ fn new_game_focus_navigation() {
     if let Screen::NewGame(ref state) = app.screen {
         assert_eq!(state.focus, NewGameFocus::AiModel);
     }
+    // Down to ReasoningEffort.
+    handle_input(&mut app, KeyCode::Down);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.focus, NewGameFocus::ReasoningEffort);
+    }
+}
+
+#[test]
+fn reasoning_effort_toggle() {
+    let mut app = new_game_app();
+    // Navigate to ReasoningEffort row.
+    // StartButton -> PlayerCount -> P1 -> P2 -> P3 -> FriendlyRobber -> BoardLayout -> AiModel -> ReasoningEffort
+    for _ in 0..8 {
+        handle_input(&mut app, KeyCode::Down);
+    }
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.focus, NewGameFocus::ReasoningEffort);
+        assert_eq!(state.effort_index, 0); // "low"
+    }
+    // Cycle forward: low -> medium.
+    handle_input(&mut app, KeyCode::Right);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 1); // "medium"
+    }
+    // Cycle forward: medium -> high.
+    handle_input(&mut app, KeyCode::Right);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 2); // "high"
+    }
+    // Cycle backward: high -> medium.
+    handle_input(&mut app, KeyCode::Left);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 1); // "medium"
+    }
+}
+
+#[test]
+fn reasoning_effort_updates_all_players() {
+    let mut app = new_game_app();
+    // Navigate to ReasoningEffort row.
+    for _ in 0..8 {
+        handle_input(&mut app, KeyCode::Down);
+    }
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.focus, NewGameFocus::ReasoningEffort);
+    }
+    // Cycle forward: low -> medium.
+    handle_input(&mut app, KeyCode::Right);
+    if let Screen::NewGame(ref state) = app.screen {
+        assert_eq!(state.effort_index, 1);
+        // All player configs should be updated.
+        for pc in &state.players {
+            assert_eq!(pc.effort_index, 1, "all players should have effort_index=1");
+        }
+    }
 }
 
 #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1279,6 +1279,7 @@ fn focusable_rows(state: &NewGameState) -> Vec<NewGameFocus> {
     rows.push(NewGameFocus::FriendlyRobber);
     rows.push(NewGameFocus::BoardLayout);
     rows.push(NewGameFocus::AiModel);
+    rows.push(NewGameFocus::ReasoningEffort);
     rows
 }
 
@@ -1332,6 +1333,18 @@ fn cycle_new_game_value(state: &mut NewGameState, forward: bool) {
                         .checked_sub(1)
                         .unwrap_or(state.model_names.len() - 1)
                 };
+            }
+        }
+        NewGameFocus::ReasoningEffort => {
+            let n = crate::config::EFFORT_LEVELS.len();
+            state.effort_index = if forward {
+                (state.effort_index + 1) % n
+            } else {
+                state.effort_index.checked_sub(1).unwrap_or(n - 1)
+            };
+            // Update all AI player configs to match.
+            for pc in &mut state.players {
+                pc.effort_index = state.effort_index;
             }
         }
         NewGameFocus::StartButton => {}
@@ -1415,6 +1428,11 @@ fn launch_game(
                     personality,
                     Some(slot_id),
                 );
+
+                // Set reasoning effort from the player config.
+                if let Some(&level) = crate::config::EFFORT_LEVELS.get(pc.effort_index) {
+                    llm.set_effort(level.to_string());
+                }
 
                 // Set up streaming reasoning bridge: LlmPlayer -> String chunks -> UiEvent.
                 let (reasoning_tx, mut reasoning_rx) = mpsc::unbounded_channel::<String>();
@@ -1545,6 +1563,9 @@ fn resume_game(
                 personality,
                 Some(slot_id),
             );
+
+            // Set reasoning effort from config default.
+            llm.set_effort(config.default_effort.clone());
 
             let (reasoning_tx, mut reasoning_rx) = mpsc::unbounded_channel::<String>();
             llm.set_reasoning_sender(reasoning_tx);
@@ -1738,6 +1759,7 @@ fn clone_new_game_state(ng: &NewGameState) -> NewGameState {
         random_board: ng.random_board,
         model_index: ng.model_index,
         model_names: ng.model_names.clone(),
+        effort_index: ng.effort_index,
     }
 }
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -68,6 +68,7 @@ pub struct PlayerConfig {
     pub name: String,
     pub kind: PlayerKind,
     pub personality_index: usize,
+    pub effort_index: usize,
 }
 
 const DEFAULT_NAMES: &[&str] = &["Marco", "Leif", "Vasco"];
@@ -85,6 +86,8 @@ pub enum NewGameFocus {
     BoardLayout,
     /// AI Model Size toggle.
     AiModel,
+    /// Reasoning effort level toggle.
+    ReasoningEffort,
     /// The "Start Game" button.
     StartButton,
 }
@@ -105,6 +108,8 @@ pub struct NewGameState {
     pub model_index: usize,
     /// Cached model display names from the config.
     pub model_names: Vec<String>,
+    /// Selected reasoning effort index into EFFORT_LEVELS.
+    pub effort_index: usize,
 }
 
 impl NewGameState {
@@ -122,6 +127,11 @@ impl NewGameState {
 
         let model_names: Vec<String> = config.models.iter().map(|m| m.name.clone()).collect();
 
+        let effort_index = crate::config::EFFORT_LEVELS
+            .iter()
+            .position(|&l| l == config.default_effort)
+            .unwrap_or(crate::config::DEFAULT_EFFORT_INDEX);
+
         let username = std::env::var("USER")
             .ok()
             .filter(|s| !s.is_empty())
@@ -134,12 +144,14 @@ impl NewGameState {
                         name: username.clone(),
                         kind: PlayerKind::Human,
                         personality_index: 0,
+                        effort_index,
                     }
                 } else {
                     PlayerConfig {
                         name: DEFAULT_NAMES[i - 1].into(),
                         kind: PlayerKind::Llamafile,
                         personality_index: i.min(personality_names.len().saturating_sub(1)),
+                        effort_index,
                     }
                 }
             })
@@ -154,6 +166,7 @@ impl NewGameState {
             random_board: false,
             model_index: 0,
             model_names,
+            effort_index,
         }
     }
 
@@ -366,6 +379,7 @@ impl SettingsState {
         let config = Config {
             models: self.models.clone(),
             hooks: Vec::new(),
+            default_effort: crate::config::default_effort(),
         };
         let _ = crate::config::save_config(&config);
         config
@@ -707,6 +721,21 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
             .map(|s| s.as_str())
             .unwrap_or("(none)"),
         ms_focused,
+    );
+
+    // Reasoning Effort.
+    let re_y = ms_y + 1;
+    let re_focused = matches!(state.focus, NewGameFocus::ReasoningEffort);
+    draw_toggle_row(
+        f,
+        x_start,
+        re_y,
+        content_width,
+        "Reasoning Effort",
+        crate::config::EFFORT_LEVELS
+            .get(state.effort_index)
+            .unwrap_or(&"low"),
+        re_focused,
     );
 
     // Hint bar at bottom.

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game.snap
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
                                                           Friendly Robber     Off
                                                           Board Layout        Beginner
                                                           AI Model            Bonsai 1.7B (fast)
-
+                                                          Reasoning Effort    low
 
 
 

--- a/src/ui/snapshots/settl__ui__snapshot_tests__new_game_llamafile.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__new_game_llamafile.snap
@@ -21,7 +21,7 @@ expression: buffer_to_string(&buf)
                                                           Friendly Robber     Off
                                                           Board Layout        Beginner
                                                           AI Model            Bonsai 1.7B (fast)
-
+                                                          Reasoning Effort    low
 
 
 


### PR DESCRIPTION
## Description

Adds reasoning effort as a configurable parameter for AI players. The effort level controls the Anthropic API's `output_config.effort` field (low/medium/high/max).

- Global default stored in `~/.settl/config.toml` (defaults to "low" for fast games)
- Configurable on the new game screen via "Reasoning Effort" toggle in RULES section
- Changing the global toggle updates all AI players
- Headless mode: `cargo run -- --headless --effort high`

Fixes #59

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)