### PR TITLE
feat: add TUI shortcut to view llamafile server logs

### DIFF
--- a/src/llamafile/mod.rs
+++ b/src/llamafile/mod.rs
@@ -2,7 +2,7 @@ pub mod download;
 pub mod process;
 
 pub use download::{ensure_llamafile, ensure_llamafile_custom, LlamafileModel};
-pub use process::LlamafileProcess;
+pub use process::{LlamafileProcess, LogBuffer};
 
 /// Status updates sent from the llamafile setup task to the UI.
 #[derive(Debug, Clone)]

--- a/src/llamafile/process.rs
+++ b/src/llamafile/process.rs
@@ -1,11 +1,20 @@
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use tokio::process::{Child, Command};
+
+/// Maximum number of stderr lines to retain in memory.
+const MAX_LOG_LINES: usize = 500;
+
+/// Shared buffer of llamafile stderr log lines.
+pub type LogBuffer = Arc<Mutex<Vec<String>>>;
 
 /// Owns a running llamafile child process. Kills it on drop.
 pub struct LlamafileProcess {
     child: Child,
     pub port: u16,
+    /// Buffered stderr output, updated by a background reader task.
+    pub log_buffer: LogBuffer,
 }
 
 impl LlamafileProcess {
@@ -101,7 +110,12 @@ impl LlamafileProcess {
                 .map_err(|e| format!("Failed to spawn llamafile: {}", e))?
         };
 
-        let mut process = Self { child, port };
+        let log_buffer: LogBuffer = Arc::new(Mutex::new(Vec::new()));
+        let mut process = Self {
+            child,
+            port,
+            log_buffer: Arc::clone(&log_buffer),
+        };
 
         let url = format!("http://127.0.0.1:{}/health", port);
         let client = reqwest::Client::new();
@@ -150,6 +164,10 @@ impl LlamafileProcess {
             match client.get(&url).send().await {
                 Ok(resp) if resp.status().is_success() => {
                     log::debug!("  server ready on port {port}");
+                    // Spawn background task to read stderr into the shared log buffer.
+                    if let Some(stderr) = process.child.stderr.take() {
+                        spawn_stderr_reader(stderr, Arc::clone(&log_buffer));
+                    }
                     return Ok(process);
                 }
                 _ => {
@@ -192,6 +210,25 @@ impl Drop for LlamafileProcess {
     }
 }
 
+/// Spawn a background task that reads lines from stderr and appends to the buffer.
+fn spawn_stderr_reader(stderr: tokio::process::ChildStderr, buffer: LogBuffer) {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+
+    tokio::spawn(async move {
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Ok(mut buf) = buffer.lock() {
+                buf.push(line);
+                if buf.len() > MAX_LOG_LINES {
+                    let excess = buf.len() - MAX_LOG_LINES;
+                    buf.drain(..excess);
+                }
+            }
+        }
+    });
+}
+
 /// Check if a TCP port is available by attempting to bind to it.
 fn is_port_available(port: u16) -> bool {
     std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
@@ -217,7 +254,11 @@ mod tests {
             "process should be alive before drop"
         );
 
-        let process = LlamafileProcess { child, port: 0 };
+        let process = LlamafileProcess {
+            child,
+            port: 0,
+            log_buffer: Arc::new(Mutex::new(Vec::new())),
+        };
         drop(process);
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -991,6 +991,41 @@ fn spectating_tab_toggles_ai_panel() {
 }
 
 #[test]
+fn spectating_l_toggles_llamafile_log() {
+    let (mut ps, _rx) = make_test_playing_state(InputMode::Spectating);
+    // Set a log buffer so the L key is active.
+    ps.llamafile_log = Some(std::sync::Arc::new(std::sync::Mutex::new(vec![
+        "test log line".into(),
+    ])));
+    let mut app = make_test_app(Screen::Playing(ps));
+
+    handle_input(&mut app, KeyCode::Char('L'));
+    assert!(match &app.screen {
+        Screen::Playing(ps) => ps.show_llamafile_log,
+        _ => panic!(),
+    });
+
+    handle_input(&mut app, KeyCode::Char('L'));
+    assert!(!match &app.screen {
+        Screen::Playing(ps) => ps.show_llamafile_log,
+        _ => panic!(),
+    });
+}
+
+#[test]
+fn spectating_l_ignored_without_llamafile() {
+    let (ps, _rx) = make_test_playing_state(InputMode::Spectating);
+    // No llamafile_log set (None) -- L should do nothing.
+    let mut app = make_test_app(Screen::Playing(ps));
+
+    handle_input(&mut app, KeyCode::Char('L'));
+    assert!(!match &app.screen {
+        Screen::Playing(ps) => ps.show_llamafile_log,
+        _ => panic!(),
+    });
+}
+
+#[test]
 fn spectating_jk_scrolls_chat_when_ai_panel_visible() {
     let (mut ps, _rx) = make_test_playing_state(InputMode::Spectating);
     ps.show_ai_panel = true;

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -108,6 +108,22 @@ fn draw_board_placeholder(f: &mut Frame, area: Rect, msg: &str) {
 
 /// Draw the playing screen with text-rendered board.
 pub fn draw_playing(f: &mut Frame, ps: &PlayingState) {
+    // Fullscreen llamafile log mode.
+    if ps.show_llamafile_log {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(f.area());
+
+        draw_llamafile_log(f, ps, chunks[0]);
+        draw_status_bar(f, ps, chunks[1]);
+
+        if ps.show_help {
+            draw_help_overlay(f, f.area());
+        }
+        return;
+    }
+
     // Fullscreen chat mode: chat takes everything except the status bar.
     if ps.show_ai_panel {
         let chunks = Layout::default()
@@ -427,6 +443,57 @@ fn draw_status_bar(f: &mut Frame, ps: &PlayingState, area: Rect) {
     ]);
     let status_paragraph = Paragraph::new(status);
     f.render_widget(status_paragraph, area);
+}
+
+// ── Llamafile Log ────────────────────────────────────────────────
+
+/// Draw a fullscreen llamafile server log viewer with auto-scroll.
+fn draw_llamafile_log(f: &mut Frame, ps: &PlayingState, area: Rect) {
+    let block = Block::default()
+        .title(Span::styled(
+            " Llamafile Server Log ",
+            Style::default().fg(Color::Yellow).bold(),
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let log_lines: Vec<String> = if let Some(ref log_buf) = ps.llamafile_log {
+        if let Ok(buf) = log_buf.lock() {
+            buf.clone()
+        } else {
+            vec!["(failed to read log buffer)".into()]
+        }
+    } else {
+        vec!["(no llamafile process)".into()]
+    };
+    let lines: Vec<Line> = log_lines
+        .iter()
+        .map(|line| {
+            Line::from(Span::styled(
+                line.as_str(),
+                Style::default().fg(Color::White),
+            ))
+        })
+        .collect();
+
+    let visible = inner.height as usize;
+    let total = lines.len();
+    let max_scroll = total.saturating_sub(visible) as u16;
+    // Auto-scroll to bottom unless user has scrolled up.
+    let effective_scroll = ps.llamafile_log_scroll.min(max_scroll);
+    let auto_scroll = effective_scroll == max_scroll || ps.llamafile_log_scroll > max_scroll;
+    let scroll = if auto_scroll {
+        max_scroll
+    } else {
+        effective_scroll
+    };
+
+    let para = Paragraph::new(lines)
+        .scroll((scroll, 0))
+        .wrap(Wrap { trim: false });
+    f.render_widget(para, inner);
 }
 
 // ── Help Overlay ──────────────────────────────────────────────────

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -196,6 +196,12 @@ pub struct PlayingState {
     pub show_ai_panel: bool,
     /// Whether to show the help overlay (? toggle).
     pub show_help: bool,
+    /// Whether to show the llamafile server log (L toggle).
+    pub show_llamafile_log: bool,
+    /// Scroll offset for the llamafile log viewer.
+    pub llamafile_log_scroll: u16,
+    /// Shared buffer of llamafile stderr lines (None if not using llamafile).
+    pub llamafile_log: Option<crate::llamafile::process::LogBuffer>,
     /// Current input mode (replaces pending_prompt).
     pub input_mode: InputMode,
     /// Channel to receive human prompts from the engine.
@@ -235,6 +241,9 @@ impl PlayingState {
             paused: false,
             show_ai_panel: false,
             show_help: false,
+            show_llamafile_log: false,
+            llamafile_log_scroll: 0,
+            llamafile_log: None,
             input_mode: InputMode::Spectating,
             human_prompt_rx: None,
             human_response_tx: None,
@@ -576,15 +585,22 @@ async fn run_event_loop(
                                     );
                                     if is_api {
                                         // API models don't need llamafile -- launch directly.
-                                        let screen =
-                                            launch_game(ng, &app.personalities, &app.config, None);
+                                        let screen = launch_game(
+                                            ng,
+                                            &app.personalities,
+                                            &app.config,
+                                            None,
+                                            None,
+                                        );
                                         app.screen = screen;
                                     } else if let Some(ref process) = app.llamafile_process {
+                                        let log_buf = Some(process.log_buffer.clone());
                                         let screen = launch_game(
                                             ng,
                                             &app.personalities,
                                             &app.config,
                                             Some(process.port),
+                                            log_buf,
                                         );
                                         app.screen = screen;
                                     } else {
@@ -619,14 +635,17 @@ async fn run_event_loop(
                                             &app.personalities,
                                             &app.config,
                                             None,
+                                            None,
                                         );
                                         app.screen = screen;
                                     } else if let Some(ref process) = app.llamafile_process {
+                                        let log_buf = Some(process.log_buffer.clone());
                                         let screen = resume_game(
                                             save,
                                             &app.personalities,
                                             &app.config,
                                             Some(process.port),
+                                            log_buf,
                                         );
                                         app.screen = screen;
                                     } else {
@@ -676,14 +695,16 @@ async fn run_event_loop(
                 if let Screen::LlamafileSetup(setup) =
                     std::mem::replace(&mut app.screen, Screen::MainMenu(MainMenuState::new()))
                 {
+                    let log_buf = app.llamafile_process.as_ref().map(|p| p.log_buffer.clone());
                     let screen = if let Some(save) = setup.resume_save {
-                        resume_game(save, &app.personalities, &app.config, Some(port))
+                        resume_game(save, &app.personalities, &app.config, Some(port), log_buf)
                     } else {
                         launch_game(
                             &setup.saved_config,
                             &app.personalities,
                             &app.config,
                             Some(port),
+                            log_buf,
                         )
                     };
                     app.screen = screen;
@@ -905,6 +926,11 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                     ps.show_ai_panel = !ps.show_ai_panel;
                     return Action::None;
                 }
+                // L toggles llamafile server log (only when llamafile is active).
+                KeyCode::Char('L') if ps.llamafile_log.is_some() => {
+                    ps.show_llamafile_log = !ps.show_llamafile_log;
+                    return Action::None;
+                }
                 _ => {}
             }
 
@@ -926,14 +952,18 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                         }
                         KeyCode::Char(' ') => ps.paused = !ps.paused,
                         KeyCode::Up | KeyCode::Char('k') => {
-                            if ps.show_ai_panel {
+                            if ps.show_llamafile_log {
+                                ps.llamafile_log_scroll = ps.llamafile_log_scroll.saturating_sub(1);
+                            } else if ps.show_ai_panel {
                                 ps.chat_scroll = ps.chat_scroll.saturating_sub(1);
                             } else {
                                 ps.log_scroll = ps.log_scroll.saturating_sub(1);
                             }
                         }
                         KeyCode::Down | KeyCode::Char('j') => {
-                            if ps.show_ai_panel {
+                            if ps.show_llamafile_log {
+                                ps.llamafile_log_scroll = ps.llamafile_log_scroll.saturating_add(1);
+                            } else if ps.show_ai_panel {
                                 ps.chat_scroll = ps.chat_scroll.saturating_add(1);
                             } else {
                                 ps.log_scroll = ps.log_scroll.saturating_add(1);
@@ -1358,6 +1388,7 @@ fn launch_game(
     discovered_personalities: &[Personality],
     config: &crate::config::Config,
     llamafile_port: Option<u16>,
+    llamafile_log: Option<crate::llamafile::process::LogBuffer>,
 ) -> Screen {
     use player::tui_human::{HumanInputChannel, TuiHumanPlayer};
     use std::sync::Arc;
@@ -1488,6 +1519,7 @@ fn launch_game(
     });
 
     let mut ps = PlayingState::new(rx, player_names, has_human);
+    ps.llamafile_log = llamafile_log;
     if let Some((_, prompt_rx, response_tx)) = human_channels {
         ps.human_prompt_rx = Some(prompt_rx);
         ps.human_response_tx = Some(response_tx);
@@ -1501,6 +1533,7 @@ fn resume_game(
     discovered_personalities: &[Personality],
     config: &crate::config::Config,
     llamafile_port: Option<u16>,
+    llamafile_log: Option<crate::llamafile::process::LogBuffer>,
 ) -> Screen {
     use player::tui_human::{HumanInputChannel, TuiHumanPlayer};
     use std::sync::Arc;
@@ -1604,6 +1637,7 @@ fn resume_game(
     });
 
     let mut ps = PlayingState::new(rx, player_names, has_human);
+    ps.llamafile_log = llamafile_log;
     if let Some((_, prompt_rx, response_tx)) = human_channels {
         ps.human_prompt_rx = Some(prompt_rx);
         ps.human_response_tx = Some(response_tx);


### PR DESCRIPTION
## Description

Adds a fullscreen llamafile server log viewer accessible via the `L` key during gameplay. Llamafile stderr is captured into a ring buffer (500 lines) by a background reader task. The viewer auto-scrolls to the latest output and supports manual scrolling with j/k.

Only available when a llamafile process is active (the shortcut is ignored for API-backed games).

Fixes #75

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)