### PR TITLE
feat: warn when system RAM is insufficient for llamafile

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,34 @@ pub enum ModelBackend {
     },
 }
 
+impl ModelEntry {
+    /// Estimate minimum RAM in GB needed for a llamafile model.
+    /// Returns `None` for API models (no local RAM needed).
+    pub fn min_ram_gb(&self) -> Option<u32> {
+        match &self.backend {
+            ModelBackend::Llamafile { filename, .. } => {
+                // Check known built-in models first.
+                if filename.contains("1.7B") {
+                    Some(crate::llamafile::LlamafileModel::Bonsai1B.min_ram_gb())
+                } else if filename.contains("8B") {
+                    Some(crate::llamafile::LlamafileModel::Bonsai8B.min_ram_gb())
+                } else {
+                    // Custom llamafile: estimate from file size if it exists on disk.
+                    let path = crate::llamafile::download::llamafile_dir().join(filename);
+                    if let Ok(meta) = std::fs::metadata(&path) {
+                        Some(crate::llamafile::download::estimate_ram_gb_from_file_size(
+                            meta.len(),
+                        ))
+                    } else {
+                        None
+                    }
+                }
+            }
+            ModelBackend::Api { .. } => None,
+        }
+    }
+}
+
 /// Valid effort levels for the Anthropic Messages API.
 pub const EFFORT_LEVELS: &[&str] = &["low", "medium", "high", "max"];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ pub mod hooks;
 pub mod llamafile;
 pub mod logging;
 pub mod player;
+pub mod system_info;
 pub mod trading;
 pub mod ui;

--- a/src/llamafile/download.rs
+++ b/src/llamafile/download.rs
@@ -36,6 +36,23 @@ impl LlamafileModel {
             Self::Bonsai8B => "8B (smart)",
         }
     }
+
+    /// Minimum RAM in GB recommended to run this model.
+    pub fn min_ram_gb(self) -> u32 {
+        match self {
+            Self::Bonsai1B => 4,
+            Self::Bonsai8B => 12,
+        }
+    }
+}
+
+/// Estimate minimum RAM (in GB) for a llamafile based on its file size.
+///
+/// Heuristic: the model needs roughly 2x its file size in RAM (weights
+/// plus inference buffers and KV cache with `--parallel 4`).
+pub fn estimate_ram_gb_from_file_size(file_size_bytes: u64) -> u32 {
+    let size_gb = file_size_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    (size_gb * 2.0).ceil().max(2.0) as u32
 }
 
 /// Minimum file size to consider a cached llamafile valid (100 MB).

--- a/src/system_info.rs
+++ b/src/system_info.rs
@@ -1,0 +1,59 @@
+//! System information detection (RAM, etc.) for resource warnings.
+
+/// Detect total system RAM in GB.
+///
+/// Returns `None` if detection fails (unsupported platform, permission error, etc.).
+pub fn total_ram_gb() -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        linux_total_ram_gb()
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos_total_ram_gb()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_total_ram_gb() -> Option<u32> {
+    let contents = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb_str = rest.trim().strip_suffix("kB")?.trim();
+            let kb: u64 = kb_str.parse().ok()?;
+            return Some((kb / (1024 * 1024)) as u32);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn macos_total_ram_gb() -> Option<u32> {
+    let output = std::process::Command::new("sysctl")
+        .arg("-n")
+        .arg("hw.memsize")
+        .output()
+        .ok()?;
+    let bytes_str = String::from_utf8_lossy(&output.stdout);
+    let bytes: u64 = bytes_str.trim().parse().ok()?;
+    Some((bytes / (1024 * 1024 * 1024)) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn total_ram_gb_returns_reasonable_value() {
+        // On any CI/dev machine this should return Some with > 0 GB.
+        if let Some(ram) = total_ram_gb() {
+            assert!(ram > 0, "RAM should be > 0 GB, got {ram}");
+            assert!(ram < 4096, "RAM should be < 4 TB, got {ram}");
+        }
+        // On unsupported platforms, None is fine.
+    }
+}

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -363,6 +363,34 @@ fn new_game_enter_starts_game_from_any_focus() {
     }
 }
 
+#[test]
+fn new_game_ram_warning_enter_proceeds() {
+    let mut app = new_game_app();
+    if let Screen::NewGame(ref mut state) = app.screen {
+        state.ram_warning = Some((12, 6));
+    }
+    // Enter should dismiss warning and trigger StartGame.
+    let action = handle_input(&mut app, KeyCode::Enter);
+    assert!(matches!(action, Action::StartGame));
+    if let Screen::NewGame(ref state) = app.screen {
+        assert!(state.ram_warning.is_none(), "warning should be cleared");
+    }
+}
+
+#[test]
+fn new_game_ram_warning_esc_dismisses() {
+    let mut app = new_game_app();
+    if let Screen::NewGame(ref mut state) = app.screen {
+        state.ram_warning = Some((12, 6));
+    }
+    // Esc should just dismiss the warning, not navigate away.
+    let action = handle_input(&mut app, KeyCode::Esc);
+    assert!(matches!(action, Action::None));
+    if let Screen::NewGame(ref state) = app.screen {
+        assert!(state.ram_warning.is_none(), "warning should be cleared");
+    }
+}
+
 // ── ActionBar ────────────────────────────────────────────────────────
 
 #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -588,6 +588,23 @@ async fn run_event_loop(
                                         );
                                         app.screen = screen;
                                     } else {
+                                        // Check RAM before starting llamafile.
+                                        if let Some(required) =
+                                            model_entry.and_then(|e| e.min_ram_gb())
+                                        {
+                                            if let Some(available) =
+                                                crate::system_info::total_ram_gb()
+                                            {
+                                                if available < required {
+                                                    if let Screen::NewGame(ref mut ng) = app.screen
+                                                    {
+                                                        ng.ram_warning =
+                                                            Some((required, available));
+                                                    }
+                                                    continue;
+                                                }
+                                            }
+                                        }
                                         let (status_tx, status_rx) = mpsc::unbounded_channel();
                                         let saved_config = clone_new_game_state(ng);
                                         let (url, filename) = llamafile_url_filename(model_entry);
@@ -829,27 +846,44 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
 
         Screen::Settings(state) => handle_settings_input(state, key, &mut app.config),
 
-        Screen::NewGame(state) => match key {
-            KeyCode::Esc => Action::Transition(Screen::MainMenu(MainMenuState::new())),
-            KeyCode::Up | KeyCode::Char('k') => {
-                move_new_game_focus_up(state);
-                Action::None
+        Screen::NewGame(state) => {
+            // RAM warning popup intercepts input when visible.
+            if state.ram_warning.is_some() {
+                match key {
+                    KeyCode::Enter => {
+                        // User chose to proceed anyway.
+                        state.ram_warning = None;
+                        return Action::StartGame;
+                    }
+                    _ => {
+                        // Any other key dismisses the warning.
+                        state.ram_warning = None;
+                        return Action::None;
+                    }
+                }
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                move_new_game_focus_down(state);
-                Action::None
+            match key {
+                KeyCode::Esc => Action::Transition(Screen::MainMenu(MainMenuState::new())),
+                KeyCode::Up | KeyCode::Char('k') => {
+                    move_new_game_focus_up(state);
+                    Action::None
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    move_new_game_focus_down(state);
+                    Action::None
+                }
+                KeyCode::Left => {
+                    cycle_new_game_value(state, false);
+                    Action::None
+                }
+                KeyCode::Right => {
+                    cycle_new_game_value(state, true);
+                    Action::None
+                }
+                KeyCode::Enter => Action::StartGame,
+                _ => Action::None,
             }
-            KeyCode::Left => {
-                cycle_new_game_value(state, false);
-                Action::None
-            }
-            KeyCode::Right => {
-                cycle_new_game_value(state, true);
-                Action::None
-            }
-            KeyCode::Enter => Action::StartGame,
-            _ => Action::None,
-        },
+        }
 
         Screen::LlamafileSetup(_) => match key {
             KeyCode::Esc => {
@@ -1760,6 +1794,7 @@ fn clone_new_game_state(ng: &NewGameState) -> NewGameState {
         model_index: ng.model_index,
         model_names: ng.model_names.clone(),
         effort_index: ng.effort_index,
+        ram_warning: None,
     }
 }
 

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -110,6 +110,8 @@ pub struct NewGameState {
     pub model_names: Vec<String>,
     /// Selected reasoning effort index into EFFORT_LEVELS.
     pub effort_index: usize,
+    /// If set, shows a RAM warning popup: (required_gb, available_gb).
+    pub ram_warning: Option<(u32, u32)>,
 }
 
 impl NewGameState {
@@ -167,6 +169,7 @@ impl NewGameState {
             model_index: 0,
             model_names,
             effort_index,
+            ram_warning: None,
         }
     }
 
@@ -747,6 +750,38 @@ pub fn draw_new_game(f: &mut Frame, state: &NewGameState) {
     .alignment(Alignment::Center)
     .style(Style::default().fg(Color::DarkGray));
     f.render_widget(hint, hint_area);
+
+    // RAM warning popup overlay.
+    if let Some((required, available)) = state.ram_warning {
+        let width = 52u16.min(area.width.saturating_sub(4));
+        let height = 7u16.min(area.height.saturating_sub(4));
+        let x = area.x + (area.width.saturating_sub(width)) / 2;
+        let y = area.y + (area.height.saturating_sub(height)) / 2;
+        let popup_area = Rect::new(x, y, width, height);
+
+        f.render_widget(Clear, popup_area);
+        let block = Block::default()
+            .title(" Low Memory Warning ")
+            .title_alignment(Alignment::Center)
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow));
+        let inner = block.inner(popup_area);
+        f.render_widget(block, popup_area);
+
+        let text = vec![
+            Line::from(Span::styled(
+                format!("Model needs ~{required} GB RAM, system has {available} GB."),
+                Style::default().fg(Color::White),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Enter: start anyway  |  Any key: cancel",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ];
+        let para = Paragraph::new(text).alignment(Alignment::Center);
+        f.render_widget(para, inner);
+    }
 }
 
 /// Draw the post-game screen.


### PR DESCRIPTION
## Description

Checks available system RAM before starting a llamafile model and shows a soft warning popup if the model's estimated RAM requirement exceeds available memory.

- RAM detection: `/proc/meminfo` on Linux, `sysctl hw.memsize` on macOS (no external deps)
- Known models: Bonsai 1.7B needs ~4 GB, Bonsai 8B needs ~12 GB
- Custom llamafiles: estimates from file size (2x heuristic)
- Soft warning: popup on the new game screen with "Enter: start anyway | Any key: cancel"
- API models are unaffected (no local RAM needed)

Fixes #71

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)