### PR TITLE
feat: add vim-style hjkl navigation for board cursor

### DIFF
--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -1204,6 +1204,67 @@ fn board_cursor_p_cycles_backward() {
 }
 
 #[test]
+fn board_cursor_hjkl_navigates() {
+    // Three positions in a row (left, center, right) and one below center.
+    let positions = vec![
+        CursorTarget {
+            screen_col: 10,
+            screen_row: 5,
+        },
+        CursorTarget {
+            screen_col: 20,
+            screen_row: 5,
+        },
+        CursorTarget {
+            screen_col: 30,
+            screen_row: 5,
+        },
+        CursorTarget {
+            screen_col: 20,
+            screen_row: 10,
+        },
+    ];
+    let (ps, _rx) = make_test_playing_state(InputMode::BoardCursor {
+        legal: CursorLegal::Settlements(Vec::new()),
+        positions,
+        selected: 1, // Start at center (col=20, row=5)
+    });
+    let mut app = make_test_app(Screen::Playing(ps));
+
+    // 'l' should move right (to index 2, col=30).
+    handle_input(&mut app, KeyCode::Char('l'));
+    if let Screen::Playing(ref ps) = app.screen {
+        if let InputMode::BoardCursor { selected, .. } = &ps.input_mode {
+            assert_eq!(*selected, 2, "'l' should move right");
+        }
+    }
+
+    // 'h' should move left (back to index 1, col=20).
+    handle_input(&mut app, KeyCode::Char('h'));
+    if let Screen::Playing(ref ps) = app.screen {
+        if let InputMode::BoardCursor { selected, .. } = &ps.input_mode {
+            assert_eq!(*selected, 1, "'h' should move left");
+        }
+    }
+
+    // 'j' should move down (to index 3, row=10).
+    handle_input(&mut app, KeyCode::Char('j'));
+    if let Screen::Playing(ref ps) = app.screen {
+        if let InputMode::BoardCursor { selected, .. } = &ps.input_mode {
+            assert_eq!(*selected, 3, "'j' should move down");
+        }
+    }
+
+    // 'k' should move up (back to index 1, row=5).
+    handle_input(&mut app, KeyCode::Char('k'));
+    if let Screen::Playing(ref ps) = app.screen {
+        if let InputMode::BoardCursor { selected, .. } = &ps.input_mode {
+            assert_eq!(*selected, 1, "'k' should move up");
+        }
+    }
+}
+
+#[test]
 fn board_cursor_enter_sends_selected_index() {
     let positions = vec![
         CursorTarget {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1046,7 +1046,14 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                 } => {
                     let len = positions.len();
                     match key {
-                        KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down => {
+                        KeyCode::Left
+                        | KeyCode::Right
+                        | KeyCode::Up
+                        | KeyCode::Down
+                        | KeyCode::Char('h')
+                        | KeyCode::Char('j')
+                        | KeyCode::Char('k')
+                        | KeyCode::Char('l') => {
                             if len > 0 {
                                 let cur = &positions[*selected];
                                 let cur_col = cur.screen_col as i32;
@@ -1311,10 +1318,10 @@ fn find_nearest_in_direction(
 
         // Check if position is in the direction of the pressed key (90-degree cone).
         let in_direction = match key {
-            KeyCode::Up => dy < 0 && dy.abs() >= dx.abs(),
-            KeyCode::Down => dy > 0 && dy.abs() >= dx.abs(),
-            KeyCode::Left => dx < 0 && dx.abs() >= dy.abs(),
-            KeyCode::Right => dx > 0 && dx.abs() >= dy.abs(),
+            KeyCode::Up | KeyCode::Char('k') => dy < 0 && dy.abs() >= dx.abs(),
+            KeyCode::Down | KeyCode::Char('j') => dy > 0 && dy.abs() >= dx.abs(),
+            KeyCode::Left | KeyCode::Char('h') => dx < 0 && dx.abs() >= dy.abs(),
+            KeyCode::Right | KeyCode::Char('l') => dx > 0 && dx.abs() >= dy.abs(),
             _ => false,
         };
 


### PR DESCRIPTION
## Description

Adds `h/j/k/l` as vim-style alternatives to arrow keys for navigating board cursor positions (settlement placement, road placement, robber movement).

- `h` = left, `j` = down, `k` = up, `l` = right
- Works alongside existing arrow keys (not a replacement)
- Applies to all `BoardCursor` contexts (settlements, roads, hexes)

Fixes #84

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)