### PR TITLE
fix: display human-readable phase names

### DIFF
--- a/src/ui/resource_bar.rs
+++ b/src/ui/resource_bar.rs
@@ -109,15 +109,17 @@ pub fn render_players(state: &GameState, player_names: &[String], area: Rect, bu
         ),
     ]));
 
+    let phase_label = match &state.phase {
+        crate::game::state::GamePhase::Setup { .. } => "Setup",
+        crate::game::state::GamePhase::Playing { .. } => "Playing",
+        crate::game::state::GamePhase::Discarding { .. } => "Discarding",
+        crate::game::state::GamePhase::PlacingRobber { .. } => "Placing Robber",
+        crate::game::state::GamePhase::Stealing { .. } => "Stealing",
+        crate::game::state::GamePhase::GameOver { .. } => "Game Over",
+    };
     lines.push(Line::from(vec![
         Span::styled("Phase: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            format!("{:?}", state.phase)
-                .chars()
-                .take(15)
-                .collect::<String>(),
-            Style::default().fg(Color::White),
-        ),
+        Span::styled(phase_label, Style::default().fg(Color::White)),
     ]));
 
     lines.push(Line::from(vec![

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                        ╲               ││  W:0 B:0 S:0 H:0 O:0               │
 │                      *  ╲             ╱││                                    │
 │                           ╲         ╱  ││Turn: 1                             │
-│                   ╱     ╲   ╲     ╱   ╱││Phase: Setup { round:               │
+│                   ╱     ╲   ╲     ╱   ╱││Phase: Setup                        │
 │                 ╱         ╲         ╱  ││Deck: 25 cards                      │
 │            *  ╱             ╲     ╱    ││                                    │
 │              ╱     Wheat     ╲   ╱     ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
@@ -16,7 +16,7 @@ expression: buffer_to_string(&buf)
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││  W:0 B:0 S:0 H:0 O:0               │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││                                    │
 │                                           10                   2                   9                                             ││Turn: 1                             │
-│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup { round:               │
+│                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││Phase: Setup                        │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Deck: 25 cards                      │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││                                    │
 │                               ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲   ╲     ╱   ╱     ╲                                ││                                    │


### PR DESCRIPTION
## Description
Phase label was showing truncated Rust debug format (`Playing { curre`). Now shows clean labels: Setup, Playing, Discarding, Placing Robber, Stealing, Game Over.

Fixes #86

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code
- [x] I am an AI Agent filling out this form (check box if true)