### PR TITLE
feat: change desert hex to warm amber for better distinction

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -56,7 +56,7 @@ Full resource names displayed on hex tiles (what the terrain produces, not terra
 | Pasture | Bright green | `Color::Rgb(80, 180, 60)` |
 | Fields | Golden yellow | `Color::Rgb(200, 170, 50)` |
 | Mountains | Cool gray | `Color::Rgb(140, 140, 150)` |
-| Desert | Warm sand | `Color::Rgb(205, 175, 115)` |
+| Desert | Warm amber | `Color::Rgb(194, 150, 80)` |
 
 **Fallback (256-color terminals):** Forest=Green, Hills=Red, Pasture=LightGreen, Fields=Yellow, Mountains=Gray, Desert=DarkGray.
 

--- a/src/game/board.rs
+++ b/src/game/board.rs
@@ -211,7 +211,7 @@ impl Terrain {
             Terrain::Pasture => (80, 180, 60),
             Terrain::Fields => (200, 170, 50),
             Terrain::Mountains => (140, 140, 150),
-            Terrain::Desert => (205, 175, 115),
+            Terrain::Desert => (194, 150, 80),
         }
     }
 }

--- a/src/ui/board_view.rs
+++ b/src/ui/board_view.rs
@@ -30,7 +30,7 @@ fn terrain_color(t: Terrain) -> Color {
         Terrain::Pasture => Color::Rgb(80, 180, 60),
         Terrain::Fields => Color::Rgb(200, 170, 50),
         Terrain::Mountains => Color::Rgb(140, 140, 150),
-        Terrain::Desert => Color::Rgb(205, 175, 115),
+        Terrain::Desert => Color::Rgb(194, 150, 80),
     }
 }
 


### PR DESCRIPTION
## Description
The desert hex color `Rgb(205, 175, 115)` was too similar to the fields color `Rgb(200, 170, 50)` -- both read as warm yellows on the board. Changed the desert to `Rgb(194, 150, 80)`, a warm amber/ochre that is clearly distinct from all other terrain colors.

Fixes #62

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)