### PR TITLE
docs: clean up README with badges, structure, and polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,30 @@
-# settl
+<p align="center">
+  <h1 align="center">settl</h1>
+  <p align="center">
+    A terminal hex settlement game where LLMs play against each other -- or you.
+    <br><br>
+    <a href="https://github.com/Brake-Labs/settl/actions/workflows/ci.yml"><img src="https://github.com/Brake-Labs/settl/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
+    <a href="https://settl.dev"><img src="https://img.shields.io/badge/docs-settl.dev-green" alt="Docs"></a>
+    <br>
+    <a href="https://x.com/natebrake"><img src="https://img.shields.io/badge/follow-%40natebrake-black?logo=x&logoColor=white" alt="Follow @natebrake"></a>
+  </p>
+</p>
 
-A terminal-based hex settlement game where LLMs play against each other (or you).
 Watch Claude, GPT, and Gemini negotiate trades, form grudges, and compete for longest road -- all in your terminal.
+
+<!-- Demo GIF goes here -->
+<!-- ![settl demo](assets/demo.gif) -->
+
+## Features
+
+- **Full game rules** -- settlements, cities, roads, robber, dev cards, trading, Longest Road, Largest Army
+- **Play or spectate** -- take a seat as Player 1, or watch AI opponents battle it out
+- **Multi-provider LLM players** -- Claude, GPT, Gemini, or any provider via [genai](https://crates.io/crates/genai)
+- **Local AI** -- runs entirely offline with [llamafile](https://github.com/mozilla-ai/llamafile), no API keys required
+- **Personality system** -- aggressive traders, grudge holders, cautious builders, chaos agents
+- **Visible AI reasoning** -- watch each AI's strategic thinking in real time
+- **Headless mode** -- run AI-vs-AI games for scripting and CI
 
 ## Quick Start
 
@@ -13,7 +36,7 @@ cargo run
 
 This launches the TUI. Select **New Game** to configure AI opponents and start playing. The default AI backend is [llamafile](https://github.com/mozilla-ai/llamafile) -- no API keys needed.
 
-For headless AI-vs-AI games:
+### Headless mode
 
 ```bash
 cargo run -- --demo            # Random AI, no API keys
@@ -21,27 +44,55 @@ cargo run -- --headless        # LLM AI via llamafile
 cargo run -- --demo --seed 42  # Reproducible board
 ```
 
-## Features
+### Cloud providers
 
-- **Full game rules** -- settlements, cities, roads, robber, development cards, trading, Longest Road, Largest Army
-- **Play or spectate** -- Player 1 is human in TUI mode; watch AI opponents play around you
-- **Multi-provider LLM players** -- Claude, GPT, Gemini, or any provider via [genai](https://crates.io/crates/genai)
-- **Local AI** -- runs entirely offline with llamafile, no API keys required
-- **Personality system** -- aggressive traders, grudge holders, cautious builders, chaos agents
-- **Visible AI reasoning** -- watch each AI's strategic thinking in real time
+Set environment variables to use hosted LLMs:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...   # Claude
+export OPENAI_API_KEY=sk-...          # GPT
+export GOOGLE_API_KEY=...             # Gemini
+```
+
+Then pass `--model` to select the model:
+
+```bash
+cargo run -- --headless --model claude-sonnet-4-6
+cargo run -- --models "claude-sonnet-4-6,gpt-4o-mini,claude-haiku-4-5-20251001"
+```
+
+## How It Works
+
+settl is a turn-based hex settlement game. Players collect resources from terrain tiles, build roads and settlements, trade with each other, and race to 10 victory points.
+
+AI players use tool-calling LLMs to make decisions. Each AI has a persistent conversation with a system prompt that includes the board state, legal moves, and a personality profile. Decisions come back as structured JSON tool calls -- no free-text parsing.
+
+The TUI renders the hex board, player stats, a scrollable game log, and a real-time AI reasoning panel. The game engine runs headless in a background task; the TUI is an optional observer.
 
 ## Documentation
 
-Full docs are available in the `docs/` directory and at the [docs site](https://settl.dev):
+Full docs are available in `docs/` and at [settl.dev](https://settl.dev):
 
-- [Getting Started](docs/getting-started.md) -- Installation, first game, CLI options
-- [How to Play](docs/how-to-play.md) -- Game rules, building, trading, winning
-- [Controls](docs/controls.md) -- Keyboard shortcuts and interaction patterns
-- [AI Players](docs/ai-players.md) -- LLM providers, personalities, spectator mode
-- [Development](docs/development.md) -- Contributing, architecture, testing
+- **[Getting Started](https://settl.dev/docs/getting-started/)** -- installation, first game, CLI options
+- **[How to Play](https://settl.dev/docs/how-to-play/)** -- game rules, building, trading, winning
+- **[Controls](https://settl.dev/docs/controls/)** -- keyboard shortcuts and interaction patterns
+- **[AI Players](https://settl.dev/docs/ai-players/)** -- LLM providers, personalities, spectator mode
+- **[Development](https://settl.dev/docs/development/)** -- contributing, architecture, testing
 
 Docs are also accessible from the TUI via the **Docs** menu item.
 
+## Development
+
+```bash
+cargo build                    # Debug build
+cargo build --release          # Release build
+cargo test                     # Run tests
+cargo fmt                      # Format
+cargo clippy                   # Lint
+```
+
+Debug logging writes to `~/.settl/debug.log`. See the [development docs](https://settl.dev/docs/development/) for architecture details and contribution guidelines.
+
 ## License
 
-Apache 2.0
+Apache 2.0 -- see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Description

Restructures and polishes the README, taking inspiration from [Agent of Empires](https://github.com/njbrake/agent-of-empires):

- Centered header with CI status, license, docs, and social badges
- Commented-out demo GIF placeholder (`assets/demo.gif`) ready for the upcoming asset
- New "How It Works" section explaining the game, AI integration, and TUI architecture
- Quick Start reorganized into subsections: basic usage, headless mode, cloud providers
- Documentation links updated to `settl.dev` with bold formatting
- "Headless mode" added as a listed feature

Fixes #103

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Reviewed Agent of Empires README for structural inspiration. All content sourced from existing settl docs and CLAUDE.md.

- [x] I am an AI Agent filling out this form (check box if true)