### PR TITLE
fix: add base path for GitHub Pages subdirectory deployment

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,6 +3,7 @@ import tailwind from "@astrojs/tailwind";
 import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: "https://settl.dev",
+  site: "https://brake-labs.github.io",
+  base: "/settl",
   integrations: [tailwind(), sitemap({ changefreq: "weekly" })],
 });

--- a/website/src/components/DocsSidebar.astro
+++ b/website/src/components/DocsSidebar.astro
@@ -1,14 +1,19 @@
 ---
 import { docsNav, getFlatNavItems } from '../data/docsNav';
 
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname;
 
 function normalize(path: string): string {
   return path.replace(/\/index\.html$/, '/').replace(/\.html$/, '/').replace(/\/$/, '') || '/';
 }
 
+function stripBase(path: string): string {
+  return base && path.startsWith(base) ? path.slice(base.length) || '/' : path;
+}
+
 function isActive(href: string): boolean {
-  return normalize(currentPath) === normalize(href);
+  return normalize(stripBase(currentPath)) === normalize(href);
 }
 
 const flatItems = getFlatNavItems();
@@ -18,7 +23,7 @@ const currentItem = flatItems.find((item) => isActive(item.href));
 <!-- Desktop sidebar -->
 <aside class="docs-sidebar">
   <div class="sidebar-header">
-    <a href="/docs/getting-started/" class="sidebar-logo">Documentation</a>
+    <a href={`${base}/docs/getting-started/`} class="sidebar-logo">Documentation</a>
   </div>
   <nav>
     {docsNav.map((section) => (
@@ -26,7 +31,7 @@ const currentItem = flatItems.find((item) => isActive(item.href));
         <div class="sidebar-section-title">{section.title}</div>
         {section.items.map((item) => (
           <a
-            href={item.href}
+            href={`${base}${item.href}`}
             class:list={['sidebar-link', { 'sidebar-link-active': isActive(item.href) }]}
           >
             {item.title}
@@ -51,7 +56,7 @@ const currentItem = flatItems.find((item) => isActive(item.href));
         <div class="mobile-sidebar-section-title">{section.title}</div>
         {section.items.map((item) => (
           <a
-            href={item.href}
+            href={`${base}${item.href}`}
             class:list={['mobile-sidebar-link', { 'mobile-sidebar-link-active': isActive(item.href) }]}
           >
             {item.title}

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,4 +1,5 @@
 ---
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <footer class="pt-0 pb-8 px-6">
@@ -17,10 +18,10 @@
       <div>
         <h4 class="text-gray-100 font-semibold text-sm uppercase tracking-wider mb-4">Docs</h4>
         <ul class="space-y-2 text-sm">
-          <li><a href="/docs/getting-started/" class="text-gray-400 hover:text-white transition-colors">Getting Started</a></li>
-          <li><a href="/docs/how-to-play/" class="text-gray-400 hover:text-white transition-colors">How to Play</a></li>
-          <li><a href="/docs/controls/" class="text-gray-400 hover:text-white transition-colors">Controls</a></li>
-          <li><a href="/docs/ai-players/" class="text-gray-400 hover:text-white transition-colors">AI Players</a></li>
+          <li><a href={`${base}/docs/getting-started/`} class="text-gray-400 hover:text-white transition-colors">Getting Started</a></li>
+          <li><a href={`${base}/docs/how-to-play/`} class="text-gray-400 hover:text-white transition-colors">How to Play</a></li>
+          <li><a href={`${base}/docs/controls/`} class="text-gray-400 hover:text-white transition-colors">Controls</a></li>
+          <li><a href={`${base}/docs/ai-players/`} class="text-gray-400 hover:text-white transition-colors">AI Players</a></li>
         </ul>
       </div>
 

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -1,16 +1,17 @@
 ---
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <nav class="fixed top-0 left-0 right-0 z-50 bg-surface-950/80 backdrop-blur-xl border-b border-surface-800/50">
   <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-    <a href="/" class="flex items-center gap-3 group">
+    <a href={`${base}/`} class="flex items-center gap-3 group">
       <span class="font-semibold text-lg font-display text-brand-400">settl</span>
     </a>
 
     <!-- Desktop nav -->
     <div class="hidden md:flex items-center gap-6">
-      <a href="/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Home</a>
-      <a href="/docs/getting-started/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Docs</a>
+      <a href={`${base}/`} class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Home</a>
+      <a href={`${base}/docs/getting-started/`} class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Docs</a>
       <a href="https://github.com/Brake-Labs/settl" class="text-gray-200 hover:text-white transition-colors flex items-center gap-2 text-sm font-medium py-3 px-2" target="_blank" rel="noopener">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
@@ -33,8 +34,8 @@
   <!-- Mobile dropdown -->
   <div id="mobile-menu" class="hidden md:hidden border-t border-surface-800/50 bg-surface-950/95 backdrop-blur-xl">
     <div class="max-w-6xl mx-auto px-6 py-4 flex flex-col gap-4">
-      <a href="/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Home</a>
-      <a href="/docs/getting-started/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Docs</a>
+      <a href={`${base}/`} class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Home</a>
+      <a href={`${base}/docs/getting-started/`} class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Docs</a>
       <a href="https://github.com/Brake-Labs/settl" class="text-gray-200 hover:text-white transition-colors flex items-center gap-2 text-sm font-medium" target="_blank" rel="noopener">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -4,7 +4,8 @@ interface Props {
   description: string;
 }
 
-const siteUrl = Astro.site?.toString().replace(/\/$/, '') ?? '';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const siteUrl = (Astro.site?.toString().replace(/\/$/, '') ?? '') + base;
 
 const {
   title,
@@ -70,10 +71,10 @@ const structuredData = {
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" as="style">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href={`${base}/styles.css`}>
 </head>
 <body class="gradient-bg min-h-screen text-gray-100 antialiased">
   <slot />
-  <script is:inline src="/main.js"></script>
+  <script is:inline src={`${base}/main.js`}></script>
 </body>
 </html>

--- a/website/src/layouts/Docs.astro
+++ b/website/src/layouts/Docs.astro
@@ -13,6 +13,7 @@ interface Props {
   };
 }
 
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const { frontmatter } = Astro.props;
 const currentPath = Astro.url.pathname;
 
@@ -20,8 +21,12 @@ function normalize(path: string): string {
   return path.replace(/\/index\.html$/, '/').replace(/\.html$/, '/').replace(/\/$/, '') || '/';
 }
 
+function stripBase(path: string): string {
+  return base && path.startsWith(base) ? path.slice(base.length) || '/' : path;
+}
+
 const flatItems = getFlatNavItems();
-const currentIndex = flatItems.findIndex((item) => normalize(currentPath) === normalize(item.href));
+const currentIndex = flatItems.findIndex((item) => normalize(stripBase(currentPath)) === normalize(item.href));
 
 const prev = currentIndex > 0 ? flatItems[currentIndex - 1] : undefined;
 const next = currentIndex < flatItems.length - 1 ? flatItems[currentIndex + 1] : undefined;
@@ -42,8 +47,8 @@ const next = currentIndex < flatItems.length - 1 ? flatItems[currentIndex + 1] :
         <slot />
       </div>
       <GuideNav
-        prev={prev ? { label: prev.title, href: prev.href } : undefined}
-        next={next ? { label: next.title, href: next.href } : undefined}
+        prev={prev ? { label: prev.title, href: `${base}${prev.href}` } : undefined}
+        next={next ? { label: next.title, href: `${base}${next.href}` } : undefined}
       />
     </main>
   </div>

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -1,3 +1,4 @@
 ---
-return Astro.redirect("/docs/getting-started/");
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+return Astro.redirect(`${base}/docs/getting-started/`);
 ---

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -2,6 +2,8 @@
 import Base from '../layouts/Base.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <Base
@@ -50,7 +52,7 @@ import Footer from '../components/Footer.astro';
       </div>
 
       <div class="flex flex-col sm:flex-row gap-4 justify-start mb-16">
-        <a href="/docs/getting-started/" class="btn-primary text-base px-8 py-3.5 inline-flex items-center justify-center">
+        <a href={`${base}/docs/getting-started/`} class="btn-primary text-base px-8 py-3.5 inline-flex items-center justify-center">
           Get Started
         </a>
         <a href="https://github.com/Brake-Labs/settl" target="_blank" rel="noopener" class="btn-secondary text-base px-8 py-3.5 group inline-flex items-center justify-center gap-2" title="Star on GitHub">


### PR DESCRIPTION
## Description

The docs site at https://brake-labs.github.io/settl/ was not rendering correctly because all internal URLs were root-relative (e.g. `/styles.css`, `/docs/getting-started/`), resolving to `https://brake-labs.github.io/...` instead of the `/settl/` subdirectory. This broke CSS loading, JS loading, and all navigation links.

The reference site (agent-of-empires) works because it's deployed at a root domain where no base path is needed.

**Fix:** Add `base: "/settl"` to the Astro config and prefix all internal links with `import.meta.env.BASE_URL` across all layouts and components. Path comparison logic in the sidebar and docs layout uses a `stripBase()` helper to correctly match the current page against navigation items.

Fixes #107

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Investigated the rendering issue by comparing the live settl site HTML with the agent-of-empires reference site, identified the missing `base` path as the root cause, and applied the fix across all 8 affected files.

- [x] I am an AI Agent filling out this form (check box if true)