### PR TITLE
fix: add PlayerTradeExecuted event to clarify trade outcomes

### DIFF
--- a/src/game/event.rs
+++ b/src/game/event.rs
@@ -69,6 +69,12 @@ pub enum GameEvent {
     TradeWithdrawn {
         by: PlayerId,
     },
+    PlayerTradeExecuted {
+        proposer: PlayerId,
+        acceptor: PlayerId,
+        gave: Vec<(Resource, u32)>,
+        got: Vec<(Resource, u32)>,
+    },
     BankTradeExecuted {
         player: PlayerId,
         gave: (Resource, u32),
@@ -236,6 +242,30 @@ pub fn format_event(event: &GameEvent, player_names: &[String]) -> String {
         }
         GameEvent::TradeWithdrawn { by } => {
             format!("{} withdrew trade", name(*by))
+        }
+        GameEvent::PlayerTradeExecuted {
+            proposer,
+            acceptor,
+            gave,
+            got,
+        } => {
+            let gave_str: String = gave
+                .iter()
+                .map(|(r, n)| format!("{} {}", n, r))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let got_str: String = got
+                .iter()
+                .map(|(r, n)| format!("{} {}", n, r))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "Trade complete: {} gave [{}] to {} for [{}]",
+                name(*proposer),
+                gave_str,
+                name(*acceptor),
+                got_str
+            )
         }
         GameEvent::BankTradeExecuted { player, gave, got } => {
             format!(

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -1095,7 +1095,14 @@ impl GameOrchestrator {
                                 &counter_offer,
                                 player_id,
                             ) {
-                                Ok(()) => {}
+                                Ok(()) => {
+                                    self.record_event(GameEvent::PlayerTradeExecuted {
+                                        proposer: other_id,
+                                        acceptor: player_id,
+                                        gave: counter_offer.offering.clone(),
+                                        got: counter_offer.requesting.clone(),
+                                    });
+                                }
                                 Err(_) => {
                                     self.record_event(GameEvent::TradeWithdrawn { by: other_id });
                                 }
@@ -1116,7 +1123,14 @@ impl GameOrchestrator {
         // Step 3: Execute the trade using the trading module.
         if let Some(acceptor) = accepted_by {
             match trading::negotiation::execute_in_state(&mut self.state, &offer, acceptor) {
-                Ok(()) => {}
+                Ok(()) => {
+                    self.record_event(GameEvent::PlayerTradeExecuted {
+                        proposer: player_id,
+                        acceptor,
+                        gave: offer.offering.clone(),
+                        got: offer.requesting.clone(),
+                    });
+                }
                 Err(_) => {
                     self.record_event(GameEvent::TradeWithdrawn { by: player_id });
                 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -33,6 +33,7 @@ fn event_name(event: &GameEvent) -> &'static str {
         GameEvent::TradeRejected { .. } => "TradeRejected",
         GameEvent::TradeCountered { .. } => "TradeCountered",
         GameEvent::TradeWithdrawn { .. } => "TradeWithdrawn",
+        GameEvent::PlayerTradeExecuted { .. } => "PlayerTradeExecuted",
         GameEvent::BankTradeExecuted { .. } => "BankTradeExecuted",
         GameEvent::DevCardBought { .. } => "DevCardBought",
         GameEvent::DevCardPlayed { .. } => "DevCardPlayed",
@@ -170,6 +171,12 @@ mod tests {
                 reasoning: String::new(),
             },
             GameEvent::TradeWithdrawn { by: 0 },
+            GameEvent::PlayerTradeExecuted {
+                proposer: 0,
+                acceptor: 1,
+                gave: vec![(crate::game::board::Resource::Wood, 1)],
+                got: vec![(crate::game::board::Resource::Brick, 1)],
+            },
             GameEvent::BankTradeExecuted {
                 player: 0,
                 gave: (crate::game::board::Resource::Wood, 4),
@@ -197,13 +204,13 @@ mod tests {
         ];
 
         let names: Vec<&str> = events.iter().map(event_name).collect();
-        assert_eq!(names.len(), 18);
+        assert_eq!(names.len(), 19);
         // All names should be non-empty and unique.
         for name in &names {
             assert!(!name.is_empty());
         }
         let unique: std::collections::HashSet<&&str> = names.iter().collect();
-        assert_eq!(unique.len(), 18, "all event names should be unique");
+        assert_eq!(unique.len(), 19, "all event names should be unique");
     }
 
     #[test]

--- a/src/trading/negotiation.rs
+++ b/src/trading/negotiation.rs
@@ -249,4 +249,51 @@ mod tests {
             TradeResponse::Reject { .. }
         ));
     }
+
+    /// Regression test for GitHub issue #106:
+    /// Trading 1 Ore for 1 Wood must not affect any other resources.
+    #[test]
+    fn trade_ore_for_wood_does_not_give_extra_brick() {
+        let board = Board::default_board();
+        let mut state = GameState::new(board, 3);
+
+        // Player 0 has 2 Ore and 1 Brick (Brick must not change).
+        state.players[0].add_resource(Resource::Ore, 2);
+        state.players[0].add_resource(Resource::Brick, 1);
+
+        // Player 1 has 2 Wood.
+        state.players[1].add_resource(Resource::Wood, 2);
+
+        // Player 0 offers 1 Ore, wants 1 Wood.
+        let offer = make_offer(0, Resource::Ore, 1, Resource::Wood, 1);
+        execute_in_state(&mut state, &offer, 1).unwrap();
+
+        // Player 0: lost 1 Ore, gained 1 Wood, Brick unchanged.
+        assert_eq!(state.players[0].resource_count(Resource::Ore), 1);
+        assert_eq!(state.players[0].resource_count(Resource::Wood), 1);
+        assert_eq!(
+            state.players[0].resource_count(Resource::Brick),
+            1,
+            "Brick must not change when trading Ore for Wood"
+        );
+        assert_eq!(
+            state.players[0].resource_count(Resource::Sheep),
+            0,
+            "Sheep must remain 0"
+        );
+        assert_eq!(
+            state.players[0].resource_count(Resource::Wheat),
+            0,
+            "Wheat must remain 0"
+        );
+
+        // Player 1: gained 1 Ore, lost 1 Wood.
+        assert_eq!(state.players[1].resource_count(Resource::Ore), 1);
+        assert_eq!(state.players[1].resource_count(Resource::Wood), 1);
+        assert_eq!(
+            state.players[1].resource_count(Resource::Brick),
+            0,
+            "Acceptor Brick must remain 0"
+        );
+    }
 }


### PR DESCRIPTION
## Description

Player-to-player trades only logged `TradeProposed` and `TradeAccepted` events without confirming what resources were actually transferred. Unlike bank trades (which have `BankTradeExecuted`), player trades had no execution event. This made it impossible to distinguish dice-distributed resources from trade resources within the same turn, leading to confusion about receiving wrong resources (e.g. getting Brick when only Wood was requested).

This PR adds a `PlayerTradeExecuted` event that explicitly logs the resources transferred, covering both direct acceptance and counter-offer trade paths. Also adds a regression test verifying trades only affect the specified resources.

Fixes #106

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Full investigation of all trading code paths, implementation, and test writing done by Claude Code.

- [x] I am an AI Agent filling out this form (check box if true)