### PR TITLE
fix: re-populate game log when resuming a saved game

### DIFF
--- a/src/ui/flow_tests.rs
+++ b/src/ui/flow_tests.rs
@@ -656,3 +656,51 @@ async fn ai_reasoning_events_emitted() {
         }
     }
 }
+
+// ── Test: Resume Game Populates Game Log ────────────────────────────
+
+#[test]
+fn resume_game_populates_game_log_with_history() {
+    use crate::game::board::{HexCoord, VertexCoord, VertexDirection};
+    use crate::game::event::{format_event, GameEvent};
+
+    let player_names: Vec<String> = vec!["Alice".into(), "Bob".into(), "Charlie".into()];
+
+    let events = vec![
+        GameEvent::DiceRolled {
+            player: 0,
+            values: (3, 4),
+            total: 7,
+        },
+        GameEvent::RobberMoved {
+            player: 0,
+            to: HexCoord::new(1, 2),
+            stole_from: Some(1),
+        },
+        GameEvent::SettlementBuilt {
+            player: 1,
+            vertex: VertexCoord::new(HexCoord::new(0, 0), VertexDirection::North),
+            reasoning: "good spot".into(),
+        },
+    ];
+
+    // Format events the same way resume_game does.
+    let history_messages: Vec<String> = events
+        .iter()
+        .map(|e| format_event(e, &player_names))
+        .collect();
+
+    let (_ui_tx, ui_rx) = mpsc::unbounded_channel::<UiEvent>();
+    let mut ps = PlayingState::new(ui_rx, player_names, false);
+
+    // Pre-populate messages, matching the resume_game code path.
+    for msg in &history_messages {
+        ps.push_message(msg.clone());
+    }
+
+    // The initial 2 messages + 3 history messages should all be present.
+    assert_eq!(ps.messages.len(), 5);
+    assert!(ps.messages[2].contains("Alice rolled 7"));
+    assert!(ps.messages[3].contains("robber"));
+    assert!(ps.messages[4].contains("Bob built settlement"));
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1812,6 +1812,14 @@ fn resume_game(
     let player_names = save.player_names.clone();
     let save_configs = save.player_configs.clone();
     let model_name = save.model_name.clone();
+
+    // Format saved events for the game log before moving them to the orchestrator.
+    let history_messages: Vec<String> = save
+        .events
+        .iter()
+        .map(|e| crate::game::event::format_event(e, &player_names))
+        .collect();
+
     let events = save.events;
     let state = save.game_state;
 
@@ -1830,6 +1838,9 @@ fn resume_game(
     let human_player_index = save.player_configs.iter().position(|p| p.is_human);
 
     let mut ps = PlayingState::new(rx, player_names, has_human);
+    for msg in history_messages {
+        ps.push_message(msg);
+    }
     ps.llamafile_log = llamafile_log;
     ps.human_player_index = human_player_index;
     if let Some((_, prompt_rx, response_tx)) = human_channels {


### PR DESCRIPTION
When using "Continue", saved events were loaded onto the orchestrator for LLM context but never sent to the UI game log. Format saved events via format_event() and pre-populate PlayingState.messages so the log shows full history on resume.

Fixes #126

## Description
<!-- Describe your changes and the problem they solve -->


## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] I understand the code I am submitting
- [ ] New and existing tests pass
- [ ] Documentation was updated where necessary

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
