### PR TITLE
build(deps): bump rand from 0.9.2 to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +388,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -744,6 +764,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -1696,6 +1717,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1751,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -2150,7 +2188,7 @@ dependencies = [
  "insta",
  "log",
  "proptest",
- "rand 0.9.2",
+ "rand 0.10.0",
  "ratatui",
  "reqwest",
  "serde",
@@ -2166,7 +2204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 clap = { version = "4", features = ["derive"] }
-rand = "0.9"
+rand = "0.10"
 crossterm = "0.29"
 toml = "1.0"
 async-trait = "0.1.89"

--- a/src/game/dice.rs
+++ b/src/game/dice.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use rand::Rng;
+use rand::RngExt;
 
 use crate::game::actions::PlayerId;
 use crate::game::board::Resource;

--- a/src/player/llm_player.rs
+++ b/src/player/llm_player.rs
@@ -689,7 +689,7 @@ impl Player for LlmPlayer {
                 (idx, reasoning)
             }
             Err(_) => {
-                use rand::Rng;
+                use rand::RngExt;
                 let idx = rand::rng().random_range(0..choices.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
@@ -730,7 +730,7 @@ impl Player for LlmPlayer {
             }
             Err(_) => {
                 // Random fallback still picks from the filtered (good) set.
-                use rand::Rng;
+                use rand::RngExt;
                 let filtered_idx = rand::rng().random_range(0..filtered_vertices.len());
                 let original_idx = index_map[filtered_idx];
                 (original_idx, "[AI was confused and acted randomly]".into())
@@ -754,7 +754,7 @@ impl Player for LlmPlayer {
                 (idx, reasoning)
             }
             Err(_) => {
-                use rand::Rng;
+                use rand::RngExt;
                 let idx = rand::rng().random_range(0..legal_edges.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
@@ -782,7 +782,7 @@ impl Player for LlmPlayer {
                 (idx, reasoning)
             }
             Err(_) => {
-                use rand::Rng;
+                use rand::RngExt;
                 let idx = rand::rng().random_range(0..legal_hexes.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }
@@ -823,7 +823,7 @@ impl Player for LlmPlayer {
                 (idx, reasoning)
             }
             Err(_) => {
-                use rand::Rng;
+                use rand::RngExt;
                 let idx = rand::rng().random_range(0..targets.len());
                 (idx, "[AI was confused and acted randomly]".into())
             }

--- a/src/player/random.rs
+++ b/src/player/random.rs
@@ -1,7 +1,7 @@
 //! A random player for testing — picks uniformly at random from legal options.
 
 use async_trait::async_trait;
-use rand::Rng;
+use rand::RngExt;
 
 use crate::game::actions::{PlayerId, TradeOffer, TradeResponse};
 use crate::game::board::{EdgeCoord, HexCoord, Resource, VertexCoord};
@@ -137,7 +137,6 @@ impl Player for RandomPlayer {
             return None;
         }
 
-        use rand::Rng;
         let mut rng = rand::rng();
         let give = have[rng.random_range(0..have.len())];
         let get = want[rng.random_range(0..want.len())];


### PR DESCRIPTION
## Summary
- Upgrades `rand` from 0.9.2 to 0.10.0
- Fixes breaking API change: `Rng` extension trait was renamed to `RngExt` in rand 0.10 (the core `RngCore` trait is now `Rng`)
- Updates all `use rand::Rng` imports used for `random_range()` to `use rand::RngExt` across `dice.rs`, `random.rs`, and `llm_player.rs`

Closes #133

## Test plan
- [x] `cargo check` -- no errors or warnings
- [x] `cargo clippy` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] `cargo test` -- all 391 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)