### PR TITLE
fix: update all links from settl.dev to mozilla-ai.github.io/settl

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -45,7 +45,7 @@ jobs:
           cat > homebrew-tap/Formula/settl.rb <<RUBY
           class Settl < Formula
             desc "Terminal hex-based settlement game with LLM players"
-            homepage "https://settl.dev"
+            homepage "https://mozilla-ai.github.io/settl/"
             version "${{ steps.release.outputs.version }}"
             license "Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <br><br>
     <a href="https://github.com/mozilla-ai/settl/actions/workflows/ci.yml"><img src="https://github.com/mozilla-ai/settl/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
-    <a href="https://settl.dev"><img src="https://img.shields.io/badge/docs-settl.dev-green" alt="Docs"></a>
+    <a href="https://mozilla-ai.github.io/settl/"><img src="https://img.shields.io/badge/docs-mozilla--ai.github.io%2Fsettl-green" alt="Docs"></a>
     <br>
   </p>
 </p>
@@ -22,7 +22,7 @@ cd settl
 cargo run
 ```
 
-Runs entirely offline using [llamafile](https://github.com/mozilla-ai/llamafile), no API keys required. Full docs at [settl.dev](https://settl.dev).
+Runs entirely offline using [llamafile](https://github.com/mozilla-ai/llamafile), no API keys required. Full docs at [mozilla-ai.github.io/settl](https://mozilla-ai.github.io/settl/).
 
 ## Related Projects
 

--- a/homebrew/settl.rb
+++ b/homebrew/settl.rb
@@ -9,7 +9,7 @@
 
 class Settl < Formula
   desc "Terminal hex-based settlement game with LLM players"
-  homepage "https://settl.dev"
+  homepage "https://mozilla-ai.github.io/settl/"
   version "VERSION"
   license "Apache-2.0"
 


### PR DESCRIPTION
## Summary
- Replace all `settl.dev` references with `mozilla-ai.github.io/settl/` across README, homebrew formula, and update-homebrew workflow

## Files changed
- `README.md` — docs badge and inline link
- `.github/workflows/update-homebrew.yml` — homebrew formula homepage
- `homebrew/settl.rb` — homebrew formula homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)