### PR TITLE
fix: homebrew cask format, workflow_dispatch, install docs

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -3,23 +3,32 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., v0.1.1)'
+        required: true
 
 jobs:
   update-tap:
-    name: Update Homebrew Formula
+    name: Update Homebrew Cask
     runs-on: ubuntu-latest
     steps:
       - name: Get release info
         id: release
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Download release checksums
         run: |
-          BASE_URL="https://github.com/mozilla-ai/settl/releases/download/${{ github.event.release.tag_name }}"
+          BASE_URL="https://github.com/mozilla-ai/settl/releases/download/${{ steps.release.outputs.tag }}"
           for name in settl-darwin-amd64 settl-darwin-arm64 settl-linux-amd64 settl-linux-arm64; do
             curl -fsSL "$BASE_URL/${name}.tar.gz.sha256" -o "${name}.sha256"
             echo "Downloaded ${name}.sha256:"
@@ -39,52 +48,50 @@ jobs:
         run: |
           git clone https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/mozilla-ai/homebrew-tap.git
 
-      - name: Update formula
+      - name: Update cask
         run: |
-          mkdir -p homebrew-tap/Formula
-          cat > homebrew-tap/Formula/settl.rb <<RUBY
-          class Settl < Formula
+          mkdir -p homebrew-tap/Casks
+          cat > homebrew-tap/Casks/settl.rb <<RUBY
+          cask "settl" do
+            name "settl"
             desc "Terminal hex-based settlement game with LLM players"
-            homepage "https://mozilla-ai.github.io/settl/"
+            homepage "https://github.com/mozilla-ai/settl"
             version "${{ steps.release.outputs.version }}"
-            license "Apache-2.0"
+
+            livecheck do
+              skip "Auto-generated on release."
+            end
 
             on_macos do
-              if Hardware::CPU.intel?
+              on_intel do
                 url "https://github.com/mozilla-ai/settl/releases/download/${{ steps.release.outputs.tag }}/settl-darwin-amd64.tar.gz"
                 sha256 "${{ steps.sha.outputs.settl_darwin_amd64 }}"
+                binary "settl-darwin-amd64", target: "settl"
               end
-              if Hardware::CPU.arm?
+              on_arm do
                 url "https://github.com/mozilla-ai/settl/releases/download/${{ steps.release.outputs.tag }}/settl-darwin-arm64.tar.gz"
                 sha256 "${{ steps.sha.outputs.settl_darwin_arm64 }}"
+                binary "settl-darwin-arm64", target: "settl"
               end
             end
 
             on_linux do
-              if Hardware::CPU.intel?
+              on_intel do
                 url "https://github.com/mozilla-ai/settl/releases/download/${{ steps.release.outputs.tag }}/settl-linux-amd64.tar.gz"
                 sha256 "${{ steps.sha.outputs.settl_linux_amd64 }}"
+                binary "settl-linux-amd64", target: "settl"
               end
-              if Hardware::CPU.arm?
+              on_arm do
                 url "https://github.com/mozilla-ai/settl/releases/download/${{ steps.release.outputs.tag }}/settl-linux-arm64.tar.gz"
                 sha256 "${{ steps.sha.outputs.settl_linux_arm64 }}"
+                binary "settl-linux-arm64", target: "settl"
               end
             end
 
-            def install
-              if OS.mac? && Hardware::CPU.intel?
-                bin.install "settl-darwin-amd64" => "settl"
-              elsif OS.mac? && Hardware::CPU.arm?
-                bin.install "settl-darwin-arm64" => "settl"
-              elsif OS.linux? && Hardware::CPU.intel?
-                bin.install "settl-linux-amd64" => "settl"
-              elsif OS.linux? && Hardware::CPU.arm?
-                bin.install "settl-linux-arm64" => "settl"
+            postflight do
+              if OS.mac?
+                system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path.to_s], sudo: false
               end
-            end
-
-            test do
-              assert_match "settl", shell_output("#{bin}/settl --help")
             end
           end
           RUBY
@@ -94,7 +101,7 @@ jobs:
           cd homebrew-tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/settl.rb
+          git add Casks/settl.rb
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "settl ${{ steps.release.outputs.version }}"
           git push

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@
   <img src="assets/demo.gif" alt="settl demo" width="1200" />
 </p>
 
-## Quick Start
+## Install
+
+```bash
+brew install --cask mozilla-ai/tap/settl
+```
+
+Or build from source:
 
 ```bash
 git clone https://github.com/mozilla-ai/settl.git
@@ -26,7 +32,7 @@ Runs entirely offline using [llamafile](https://github.com/mozilla-ai/llamafile)
 
 ## Related Projects
 
-- **[Agent of Empires](https://github.com/njbrake/agent-of-empires)** - A terminal session manager for AI coding agents. Run settl inside AoE to toggle between the game and your other coding agent sessions.
+- **[Agent of Empires](https://github.com/njbrake/agent-of-empires)** - A terminal session manager for AI coding agents. If settl is installed, AoE automatically detects it and lets you spin up a settl session alongside your coding agents.
 - **[llamafile](https://github.com/mozilla-ai/llamafile)** - One-file LLM inference. settl downloads and runs a llamafile automatically so AI players work offline with zero setup.
 - **[Bonsai Models by PrismML](https://prismml.com/)** - Ultra-efficient 1-bit quantized language models that power settl's default AI players.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,13 @@ settl is a terminal hex settlement game where AI players compete using tool-call
 
 ## Installation
 
-Clone the repo and build with Cargo:
+### Homebrew (macOS / Linux)
+
+```bash
+brew install --cask mozilla-ai/tap/settl
+```
+
+### From source
 
 ```bash
 git clone https://github.com/mozilla-ai/settl.git
@@ -25,7 +31,8 @@ The binary is at `target/release/settl`.
 Launch the TUI:
 
 ```bash
-cargo run
+settl              # if installed via brew
+cargo run          # if built from source
 ```
 
 This opens the title screen. Select **New Game** to configure players and start.

--- a/homebrew/settl.rb
+++ b/homebrew/settl.rb
@@ -1,53 +1,51 @@
-# Homebrew formula for settl
+# Homebrew cask for settl
 # This is a template -- the CI workflow (update-homebrew.yml) auto-generates
-# the real formula in mozilla-ai/homebrew-tap on each release.
+# the real cask in mozilla-ai/homebrew-tap on each release.
 #
 # To bootstrap the tap manually:
 #   1. Clone git@github.com:mozilla-ai/homebrew-tap.git
-#   2. Copy this file to Formula/settl.rb
+#   2. Copy this file to Casks/settl.rb
 #   3. Replace VERSION and SHA256 placeholders with real values from a release
 
-class Settl < Formula
+cask "settl" do
+  name "settl"
   desc "Terminal hex-based settlement game with LLM players"
-  homepage "https://mozilla-ai.github.io/settl/"
+  homepage "https://github.com/mozilla-ai/settl"
   version "VERSION"
-  license "Apache-2.0"
+
+  livecheck do
+    skip "Auto-generated on release."
+  end
 
   on_macos do
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://github.com/mozilla-ai/settl/releases/download/vVERSION/settl-darwin-amd64.tar.gz"
       sha256 "SHA256_DARWIN_AMD64"
+      binary "settl-darwin-amd64", target: "settl"
     end
-    if Hardware::CPU.arm?
+    on_arm do
       url "https://github.com/mozilla-ai/settl/releases/download/vVERSION/settl-darwin-arm64.tar.gz"
       sha256 "SHA256_DARWIN_ARM64"
+      binary "settl-darwin-arm64", target: "settl"
     end
   end
 
   on_linux do
-    if Hardware::CPU.intel?
+    on_intel do
       url "https://github.com/mozilla-ai/settl/releases/download/vVERSION/settl-linux-amd64.tar.gz"
       sha256 "SHA256_LINUX_AMD64"
+      binary "settl-linux-amd64", target: "settl"
     end
-    if Hardware::CPU.arm?
+    on_arm do
       url "https://github.com/mozilla-ai/settl/releases/download/vVERSION/settl-linux-arm64.tar.gz"
       sha256 "SHA256_LINUX_ARM64"
+      binary "settl-linux-arm64", target: "settl"
     end
   end
 
-  def install
-    if OS.mac? && Hardware::CPU.intel?
-      bin.install "settl-darwin-amd64" => "settl"
-    elsif OS.mac? && Hardware::CPU.arm?
-      bin.install "settl-darwin-arm64" => "settl"
-    elsif OS.linux? && Hardware::CPU.intel?
-      bin.install "settl-linux-amd64" => "settl"
-    elsif OS.linux? && Hardware::CPU.arm?
-      bin.install "settl-linux-arm64" => "settl"
+  postflight do
+    if OS.mac?
+      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path.to_s], sudo: false
     end
-  end
-
-  test do
-    assert_match "settl", shell_output("#{bin}/settl --help")
   end
 end

--- a/src/ui/snapshots/settl__ui__snapshot_tests__docs.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__docs.snap
@@ -1,5 +1,6 @@
 ---
 source: src/ui/snapshot_tests.rs
+assertion_line: 61
 expression: buffer_to_string(&buf)
 ---
 ┌ Docs ────────────────┐┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -13,7 +14,13 @@ expression: buffer_to_string(&buf)
 │                      ││ Installation                                                                                                                                   │
 │                      ││ ------------                                                                                                                                   │
 │                      ││                                                                                                                                                │
-│                      ││ Clone the repo and build with Cargo:                                                                                                           │
+│                      ││                                                                                                                                                │
+│                      ││ Homebrew (macOS / Linux)                                                                                                                       │
+│                      ││                                                                                                                                                │
+│                      ││   brew install --cask mozilla-ai/tap/settl                                                                                                     │
+│                      ││                                                                                                                                                │
+│                      ││                                                                                                                                                │
+│                      ││ From source                                                                                                                                    │
 │                      ││                                                                                                                                                │
 │                      ││   git clone https://github.com/mozilla-ai/settl.git                                                                                            │
 │                      ││   cd settl                                                                                                                                     │
@@ -27,7 +34,8 @@ expression: buffer_to_string(&buf)
 │                      ││                                                                                                                                                │
 │                      ││ Launch the TUI:                                                                                                                                │
 │                      ││                                                                                                                                                │
-│                      ││   cargo run                                                                                                                                    │
+│                      ││   settl              # if installed via brew                                                                                                   │
+│                      ││   cargo run          # if built from source                                                                                                    │
 │                      ││                                                                                                                                                │
 │                      ││ This opens the title screen. Select New Game to configure players and start.                                                                   │
 │                      ││                                                                                                                                                │
@@ -58,12 +66,5 @@ expression: buffer_to_string(&buf)
 │                      ││                                                                                                                                                │
 │                      ││   | Flag | Description | Default |                                                                                                             │
 │                      ││   | `--headless` | Run in text mode (no TUI) | off |                                                                                           │
-│                      ││   | `--demo` | Random AI players, no API keys | off |                                                                                          │
-│                      ││   | `-p, --players N` | Number of players (2-4) | 4 |                                                                                          │
-│                      ││   | `-m, --model MODEL` | Default LLM model | claude-sonnet-4-6 |                                                                              │
-│                      ││   | `--models M1,M2,...` | Per-player model assignment | -- |                                                                                  │
-│                      ││   | `--personality FILE` | TOML personality file | built-in |                                                                                  │
-│                      ││   | `--seed N` | RNG seed for reproducible boards | random |                                                                                   │
-│                      ││                                                                                                                                                │
 └──────────────────────┘└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                     [↑↓] page  [j/k] scroll  [Esc] back

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -35,9 +35,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
           </div>
           <div class="px-5 py-4 font-mono text-sm md:text-base flex items-center justify-between gap-4">
             <code class="text-gray-100 overflow-x-auto">
-              <span class="text-gray-500 select-none">$ </span><span class="text-brand-400">git clone</span> https://github.com/mozilla-ai/settl.git && <span class="text-brand-400">cd</span> settl && <span class="text-brand-400">cargo</span> run
+              <span class="text-gray-500 select-none">$ </span><span class="text-brand-400">brew install</span> --cask mozilla-ai/tap/settl
             </code>
-            <button onclick="copyCommand('git clone https://github.com/mozilla-ai/settl.git && cd settl && cargo run', this)" class="install-copy-btn text-gray-500 hover:text-brand-400 transition-colors p-2 rounded-lg hover:bg-surface-700/50 flex-shrink-0" title="Copy to clipboard">
+            <button onclick="copyCommand('brew install --cask mozilla-ai/tap/settl', this)" class="install-copy-btn text-gray-500 hover:text-brand-400 transition-colors p-2 rounded-lg hover:bg-surface-700/50 flex-shrink-0" title="Copy to clipboard">
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
               </svg>
@@ -45,6 +45,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
           </div>
         </div>
         <p class="text-sm text-gray-500 mt-3">
+          Or build from source: <code class="text-gray-400">git clone https://github.com/mozilla-ai/settl.git && cd settl && cargo run</code>
+        </p>
+        <p class="text-sm text-gray-500 mt-1">
           Runs entirely offline using <a href="https://github.com/mozilla-ai/llamafile" class="text-gray-400 hover:text-white transition-colors">llamafile</a>. No API keys required.
         </p>
       </div>
@@ -66,7 +69,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
         <ul class="space-y-3 text-sm">
           <li>
             <a href="https://github.com/njbrake/agent-of-empires" class="text-gray-100 hover:text-white transition-colors font-medium" target="_blank" rel="noopener">Agent of Empires</a>
-            <span class="text-gray-500"> - Terminal session manager for AI coding agents</span>
+            <span class="text-gray-500"> - Terminal session manager for AI coding agents. Install settl and AoE automatically detects it, letting you spin up a game session</span>
           </li>
           <li>
             <a href="https://github.com/mozilla-ai/llamafile" class="text-gray-100 hover:text-white transition-colors font-medium" target="_blank" rel="noopener">llamafile</a>


### PR DESCRIPTION
## Summary
- Convert homebrew workflow from Formula to Cask format (matching existing `mozilla-ai/homebrew-tap` conventions)
- Add `workflow_dispatch` trigger so the tap can be updated manually for existing releases
- Fix binary naming in cask (release tarballs contain `settl-{platform}`, need `target:` rename)
- Add `brew install --cask mozilla-ai/tap/settl` to README, getting-started docs, and website hero
- Update AoE description: installing settl lets AoE auto-detect it and spin up game sessions

## Test plan
- [x] `cargo test` passes (391 tests)
- [x] Snapshot updated for new getting-started content
- [ ] After merge, manually trigger "Update Homebrew Tap" workflow with tag `v0.1.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)