### PR TITLE
feat: add update available notification on main menu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod player;
 pub mod system_info;
 pub mod trading;
 pub mod ui;
+pub mod update_check;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -509,6 +509,10 @@ pub struct App {
     pub show_size_warning: bool,
     /// Model registry and app settings, loaded from `~/.settl/config.toml`.
     pub config: crate::config::Config,
+    /// Info about a newer version, if one is available.
+    pub update_info: Option<crate::update_check::UpdateInfo>,
+    /// Receiver for the background update check result.
+    update_rx: Option<tokio::sync::oneshot::Receiver<Option<crate::update_check::UpdateInfo>>>,
 }
 
 // ── Main Entry Point ───────────────────────────────────────────────────
@@ -551,12 +555,21 @@ pub async fn run_app() -> io::Result<()> {
         }
     }
 
+    // Spawn a background task to check for updates.
+    let (update_tx, update_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        let result = crate::update_check::check_for_update().await;
+        let _ = update_tx.send(result);
+    });
+
     let mut app = App {
         screen: Screen::MainMenu(MainMenuState::new()),
         personalities,
         llamafile_process: None,
         show_size_warning,
         config,
+        update_info: None,
+        update_rx: Some(update_rx),
     };
 
     let result = run_event_loop(&mut terminal, &mut app).await;
@@ -577,7 +590,7 @@ async fn run_event_loop(
     loop {
         // Draw.
         terminal.draw(|f| {
-            draw_screen(f, &app.screen);
+            draw_screen(f, &app.screen, app.update_info.as_ref());
             if app.show_size_warning {
                 draw_size_warning(f);
             }
@@ -787,14 +800,26 @@ async fn run_event_loop(
                 }
             }
         }
+
+        // Poll for background update check result.
+        if let Some(ref mut rx) = app.update_rx {
+            if let Ok(result) = rx.try_recv() {
+                app.update_info = result;
+                app.update_rx = None;
+            }
+        }
     }
 }
 
 // ── Drawing Dispatch ───────────────────────────────────────────────────
 
-fn draw_screen(f: &mut Frame, screen: &Screen) {
+fn draw_screen(
+    f: &mut Frame,
+    screen: &Screen,
+    update_info: Option<&crate::update_check::UpdateInfo>,
+) {
     match screen {
-        Screen::MainMenu(state) => screens::draw_main_menu(f, state),
+        Screen::MainMenu(state) => screens::draw_main_menu(f, state, update_info),
         Screen::NewGame(state) => screens::draw_new_game(f, state),
         Screen::About(_) => screens::draw_about(f),
         Screen::Docs(state) => screens::draw_docs(f, state),

--- a/src/ui/screens.rs
+++ b/src/ui/screens.rs
@@ -768,7 +768,11 @@ impl PersonalitiesState {
 // ── Drawing Functions ──────────────────────────────────────────────────
 
 /// Draw the main menu.
-pub fn draw_main_menu(f: &mut Frame, state: &MainMenuState) {
+pub fn draw_main_menu(
+    f: &mut Frame,
+    state: &MainMenuState,
+    update_info: Option<&crate::update_check::UpdateInfo>,
+) {
     let area = f.area();
     f.render_widget(Clear, area);
 
@@ -776,7 +780,10 @@ pub fn draw_main_menu(f: &mut Frame, state: &MainMenuState) {
     let art_lines = TITLE_ART.lines().count() as u16;
     let items = state.menu_items();
     let menu_height = items.len() as u16;
-    let total_height = art_lines + 4 + menu_height + 2; // art + subtitle + gaps + menu + hint
+    let has_update = update_info.is_some();
+    // Reserve an extra line for the update badge below the hint bar.
+    let update_height = if has_update { 2 } else { 0 };
+    let total_height = art_lines + 4 + menu_height + 2 + update_height;
     let y_start = area.y + area.height.saturating_sub(total_height) / 2;
 
     render_title_art(f, area, y_start, art_lines);
@@ -810,6 +817,22 @@ pub fn draw_main_menu(f: &mut Frame, state: &MainMenuState) {
             .alignment(Alignment::Center)
             .style(Style::default().fg(Color::DarkGray));
         f.render_widget(hint, hint_area);
+    }
+
+    // Update badge.
+    if let Some(info) = update_info {
+        let badge_y = hint_y + 2;
+        if badge_y < area.y + area.height {
+            let badge_area = Rect::new(area.x, badge_y, area.width, 1);
+            let text = format!(
+                "update available: v{} -> v{}",
+                info.current_version, info.latest_version
+            );
+            let badge = Paragraph::new(text)
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::Yellow));
+            f.render_widget(badge, badge_area);
+        }
     }
 }
 

--- a/src/ui/testing.rs
+++ b/src/ui/testing.rs
@@ -56,7 +56,7 @@ pub fn render_app_to_buffer(app: &mut App, width: u16, height: u16) -> Buffer {
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|f| {
-            draw_screen(f, &app.screen);
+            draw_screen(f, &app.screen, app.update_info.as_ref());
             if app.show_size_warning {
                 draw_size_warning(f);
             }
@@ -130,6 +130,8 @@ pub fn make_test_app(screen: Screen) -> App {
         llamafile_process: None,
         show_size_warning: false,
         config: crate::config::Config::default(),
+        update_info: None,
+        update_rx: None,
     }
 }
 

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,216 @@
+//! Background update checker -- queries GitHub Releases API and caches results.
+//!
+//! On TUI startup, a background task checks for newer releases. Results are
+//! cached to `~/.settl/update_cache.json` and throttled by a configurable
+//! interval (default 24 hours). The main menu displays a non-intrusive badge
+//! when a newer version is available.
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// How often to re-check (in seconds). Default: 24 hours.
+const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// HTTP timeout for the GitHub API request.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// GitHub API endpoint for the latest release.
+const RELEASES_URL: &str = "https://api.github.com/repos/mozilla-ai/settl/releases/latest";
+
+/// Info about an available update.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub current_version: String,
+    pub latest_version: String,
+}
+
+/// On-disk cache so we don't hit the API on every launch.
+#[derive(Debug, Serialize, Deserialize)]
+struct UpdateCache {
+    /// Unix timestamp of the last successful check.
+    checked_at: u64,
+    /// The latest version string from GitHub (without leading 'v').
+    latest_version: String,
+}
+
+/// Check GitHub for a newer release, using the disk cache when fresh.
+///
+/// Returns `Some(UpdateInfo)` if a newer version exists, `None` otherwise.
+/// Any errors (network, parse, filesystem) are silently swallowed -- this
+/// feature must never block or crash the app.
+pub async fn check_for_update() -> Option<UpdateInfo> {
+    let current = env!("CARGO_PKG_VERSION");
+    let cache_path = cache_path();
+
+    // Try the cache first.
+    if let Some(cached) = read_cache(&cache_path) {
+        let now = now_unix();
+        if now.saturating_sub(cached.checked_at) < CHECK_INTERVAL_SECS {
+            // Cache is still fresh.
+            return if is_newer(&cached.latest_version, current) {
+                Some(UpdateInfo {
+                    current_version: current.to_string(),
+                    latest_version: cached.latest_version,
+                })
+            } else {
+                None
+            };
+        }
+    }
+
+    // Cache is stale or missing -- fetch from GitHub.
+    let latest = fetch_latest_version().await?;
+
+    // Write the cache (best-effort).
+    let _ = write_cache(&cache_path, &latest);
+
+    if is_newer(&latest, current) {
+        Some(UpdateInfo {
+            current_version: current.to_string(),
+            latest_version: latest,
+        })
+    } else {
+        None
+    }
+}
+
+/// Fetch the latest release tag from GitHub.
+async fn fetch_latest_version() -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent(concat!("settl/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .ok()?;
+
+    let resp = client.get(RELEASES_URL).send().await.ok()?;
+
+    if !resp.status().is_success() {
+        log::debug!("Update check: GitHub API returned {}", resp.status());
+        return None;
+    }
+
+    let body: serde_json::Value = resp.json().await.ok()?;
+    let tag = body.get("tag_name")?.as_str()?;
+
+    // Strip leading 'v' if present (e.g. "v0.2.0" -> "0.2.0").
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    Some(version.to_string())
+}
+
+/// Return `true` if `candidate` is a strictly newer semver than `current`.
+fn is_newer(candidate: &str, current: &str) -> bool {
+    let parse = |s: &str| -> Option<Vec<u64>> {
+        s.split('.').map(|part| part.parse::<u64>().ok()).collect()
+    };
+    let c = match parse(candidate) {
+        Some(v) => v,
+        None => return false,
+    };
+    let cur = match parse(current) {
+        Some(v) => v,
+        None => return false,
+    };
+
+    // Compare component by component (major, minor, patch, ...).
+    for (a, b) in c.iter().zip(cur.iter()) {
+        if a > b {
+            return true;
+        }
+        if a < b {
+            return false;
+        }
+    }
+    // If all shared components are equal, longer version is "newer"
+    // (e.g. "1.0.0.1" > "1.0.0").
+    c.len() > cur.len()
+}
+
+// ── Cache I/O ─────────────────────────────────────────────────────────
+
+fn cache_path() -> PathBuf {
+    let home = std::env::var("HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| ".".into());
+    PathBuf::from(home).join(".settl").join("update_cache.json")
+}
+
+fn read_cache(path: &PathBuf) -> Option<UpdateCache> {
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn write_cache(path: &PathBuf, latest_version: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir: {e}"))?;
+    }
+    let cache = UpdateCache {
+        checked_at: now_unix(),
+        latest_version: latest_version.to_string(),
+    };
+    let json = serde_json::to_string(&cache).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("write: {e}"))?;
+    Ok(())
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_version_detected() {
+        assert!(is_newer("0.2.0", "0.1.0"));
+        assert!(is_newer("1.0.0", "0.9.9"));
+        assert!(is_newer("0.1.1", "0.1.0"));
+        assert!(is_newer("2.0.0", "1.99.99"));
+    }
+
+    #[test]
+    fn same_version_not_newer() {
+        assert!(!is_newer("0.1.0", "0.1.0"));
+        assert!(!is_newer("1.0.0", "1.0.0"));
+    }
+
+    #[test]
+    fn older_version_not_newer() {
+        assert!(!is_newer("0.1.0", "0.2.0"));
+        assert!(!is_newer("0.9.0", "1.0.0"));
+    }
+
+    #[test]
+    fn malformed_versions_return_false() {
+        assert!(!is_newer("abc", "0.1.0"));
+        assert!(!is_newer("0.1.0", "abc"));
+        assert!(!is_newer("", "0.1.0"));
+        assert!(!is_newer("0.1.0", ""));
+    }
+
+    #[test]
+    fn extra_components_handled() {
+        assert!(is_newer("0.1.0.1", "0.1.0"));
+        assert!(!is_newer("0.1.0", "0.1.0.1"));
+    }
+
+    #[test]
+    fn cache_roundtrip() {
+        let dir = std::env::temp_dir().join("settl_test_cache");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("update_cache.json");
+
+        write_cache(&path, "1.2.3").unwrap();
+        let cached = read_cache(&path).unwrap();
+        assert_eq!(cached.latest_version, "1.2.3");
+        assert!(cached.checked_at > 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Description

Adds a background update check system that notifies users when a newer version of settl is available. On TUI startup, a background tokio task queries the GitHub Releases API (5-second timeout) and compares the latest release tag against the current binary version. Results are cached to `~/.settl/update_cache.json` with a 24-hour TTL to avoid hitting the API on every launch. When an update is available, a non-intrusive yellow badge appears on the main menu: `update available: v0.1.0 -> v0.2.0`. All errors are silently swallowed so the feature never blocks or crashes the app.

Modeled after the update check system in [agent-of-empires](https://github.com/njbrake/agent-of-empires).

Fixes #146

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)