### PR TITLE
feat: clarify player panel labels and simplify dice roll

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -398,15 +398,15 @@ Two keys. Fast response keeps the game moving.
  ▸ Alice        7VP
    Wood:2 Brick:1 Sheep:0
    Wheat:3 Ore:2
-   Dev:3 Kn:2  ★LR
+   Dev Cards:3 Kn:2  ★LR
 
    Bob          5VP
-   Cards: 4
-   Dev:1
+   Resources: 4
+   Dev Cards:1
 
    Carol        4VP
-   Cards: 3
-   Kn:1
+   Resources: 3
+   Dev Cards:1 Kn:1
 
  Turn 15 | Playing
  Deck: 20 cards

--- a/src/game/event.rs
+++ b/src/game/event.rs
@@ -121,18 +121,8 @@ pub fn format_event(event: &GameEvent, player_names: &[String]) -> String {
         GameEvent::InitialRoadPlaced { player, edge } => {
             format!("{} placed road at {}", name(*player), edge)
         }
-        GameEvent::DiceRolled {
-            player,
-            values,
-            total,
-        } => {
-            format!(
-                "{} rolled {} ({} + {})",
-                name(*player),
-                total,
-                values.0,
-                values.1
-            )
+        GameEvent::DiceRolled { player, total, .. } => {
+            format!("{} rolled {}", name(*player), total)
         }
         GameEvent::ResourcesDistributed { distributions } => {
             if distributions.is_empty() {

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -343,12 +343,9 @@ impl GameOrchestrator {
             total: roll,
         };
         self.record_event(dice_event.clone());
-        self.send_narration(format!("{} rolled {} ({} + {})", name, roll, d1, d2));
+        self.send_narration(format!("{} rolled {}", name, roll));
         self.send_ui(
-            format!(
-                "Turn {} -- {} rolled {} ({} + {})",
-                turn_num, name, roll, d1, d2
-            ),
+            format!("Turn {} -- {} rolled {}", turn_num, name, roll),
             Some(dice_event),
         );
 

--- a/src/ui/resource_bar.rs
+++ b/src/ui/resource_bar.rs
@@ -102,7 +102,7 @@ fn build_player_lines(
             lines.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
-                    format!("Cards: {}", total),
+                    format!("Resources: {}", total),
                     Style::default().fg(Color::DarkGray),
                 ),
             ]));
@@ -114,7 +114,7 @@ fn build_player_lines(
         let mut extras: Vec<Span> = vec![Span::raw("  ")];
         if dev > 0 {
             extras.push(Span::styled(
-                format!("Dev:{} ", dev),
+                format!("Dev Cards:{} ", dev),
                 Style::default().fg(Color::Cyan),
             ));
         }
@@ -252,8 +252,8 @@ mod tests {
 
         // Opponents show only card count, not resource breakdown.
         assert!(
-            output.contains("Cards: 0"),
-            "opponents should show card count"
+            output.contains("Resources: 0"),
+            "opponents should show resource count"
         );
         // Opponents should NOT have "Wood:" in their section.
         let bob_section = output.split("Bob").nth(1).unwrap_or("");
@@ -282,8 +282,8 @@ mod tests {
             "spectator should see all resources"
         );
         assert!(
-            !output.contains("Cards:"),
-            "spectator mode should not show card counts"
+            !output.contains("Resources:"),
+            "spectator mode should not show resource counts as totals"
         );
     }
 
@@ -297,8 +297,8 @@ mod tests {
         let output = render_to_string(&state, &names, Some(0));
 
         assert!(
-            output.contains("Cards: 5"),
-            "opponent should show total card count of 5"
+            output.contains("Resources: 5"),
+            "opponent should show total resource count of 5"
         );
     }
 }

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_action_bar_small.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                *       ││  Wheat:0 Ore:0                     │
 │                                   3:1  ││                                    │
 │                             ╱     ╲    ││ Bob 0VP                            │
-│                           ╱         ╲  ││  Cards: 0                          │
+│                           ╱         ╲  ││  Resources: 0                      │
 │                         ╱             ╲││                                    │
 │                        ╱      Ore      ││ Charlie 0VP                        │
-│                               10       ││  Cards: 0                          │
+│                               10       ││  Resources: 0                      │
 │                        ╲               ││                                    │
 │                      *  ╲             ╱││ Diana 0VP                          │
-│                           ╲         ╱  ││  Cards: 0                          │
+│                           ╲         ╱  ││  Resources: 0                      │
 │            2:Wood ╱     ╲   ╲     ╱   ╱││                                    │
 │                 ╱         ╲         ╱  ││Turn: 1                             │
 │            *  ╱             ╲     ╱    ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_board_cursor.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_discard.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_resource_picker.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_spectating.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                                                                                                                  ││  Cards: 0                          │
+│                                                                                                                                  ││  Resources: 0                      │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Charlie 0VP                        │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Diana 0VP                          │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││Turn: 1                             │
 │                                           10                   2                   9                                             ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_steal_target.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_builder.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │

--- a/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
+++ b/src/ui/snapshots/settl__ui__snapshot_tests__playing_trade_response.snap
@@ -9,13 +9,13 @@ expression: buffer_to_string(&buf)
 │                                                                                                                                  ││  Wheat:0 Ore:0                     │
 │                                                                                                                                  ││                                    │
 │                                                                                                                                  ││ Bob 0VP                            │
-│                                            *                                       *                                             ││  Cards: 0                          │
+│                                            *                                       *                                             ││  Resources: 0                      │
 │                                               3:1                                                                                ││                                    │
 │                                         ╱     ╲             ╱     ╲             ╱     ╲2:Wheat                                   ││ Charlie 0VP                        │
-│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Cards: 0                          │
+│                                       ╱         ╲         ╱         ╲         ╱         ╲                                        ││  Resources: 0                      │
 │                                     ╱             ╲  *  ╱             ╲     ╱             ╲  *                                   ││                                    │
 │                                    ╱      Ore      ╲   ╱     Sheep     ╲   ╱     Wood      ╲                                     ││ Diana 0VP                          │
-│                                           10                   2                   9                                             ││  Cards: 0                          │
+│                                           10                   2                   9                                             ││  Resources: 0                      │
 │                                    ╲               ╱   ╲               ╱   ╲               ╱                                     ││                                    │
 │                                  *  ╲             ╱     ╲             ╱     ╲             ╱                                      ││Turn: 1                             │
 │                                       ╲         ╱         ╲         ╱         ╲         ╱                                        ││Phase: Setup                        │


### PR DESCRIPTION
## Description

Clarifies the player dashboard labels so it's immediately obvious what each number means:
- Renamed opponent "Cards: N" to "Resources: N" (total resource card count)
- Renamed "Dev:N" to "Dev Cards:N" for all players
- Simplified dice roll messages from "Alice rolled 7 (3 + 4)" to "Alice rolled 7"

Updated DESIGN.md, unit tests, and all 9 snapshot tests to match.

Fixes #147

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)