### PR TITLE
feat: add lifecycle events for external status detection

### DIFF
--- a/src/game/event.rs
+++ b/src/game/event.rs
@@ -7,9 +7,29 @@ use serde::{Deserialize, Serialize};
 use crate::game::actions::{DevCard, PlayerId, TradeOffer};
 use crate::game::board::{EdgeCoord, HexCoord, Resource, VertexCoord};
 
+/// Reason the game is waiting for a human player.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WaitingReason {
+    YourTurn,
+    TradeResponse,
+    DiscardCards,
+    PlaceRobber,
+}
+
 /// Every discrete game event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum GameEvent {
+    // -- Lifecycle --
+    TurnStarted {
+        player: PlayerId,
+        is_human: bool,
+    },
+    WaitingForHuman {
+        player: PlayerId,
+        reason: WaitingReason,
+    },
+
     // -- Setup --
     InitialSettlementPlaced {
         player: PlayerId,
@@ -109,6 +129,13 @@ pub fn format_event(event: &GameEvent, player_names: &[String]) -> String {
     let name = |p: PlayerId| -> &str { player_names.get(p).map(|s| s.as_str()).unwrap_or("???") };
 
     match event {
+        GameEvent::TurnStarted { player, is_human } => {
+            let kind = if *is_human { "human" } else { "AI" };
+            format!("{}'s turn ({kind})", name(*player))
+        }
+        GameEvent::WaitingForHuman { player, reason } => {
+            format!("Waiting for {} ({:?})", name(*player), reason)
+        }
         GameEvent::InitialSettlementPlaced { player, vertex } => {
             format!(
                 "{} placed settlement at ({},{},{:?})",

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 use crate::game::actions::{Action, DevCard, DevCardAction, PlayerId, TradeResponse};
 use crate::game::board::{board_hex_coords, Resource};
 use crate::game::dice;
-use crate::game::event::GameEvent;
+use crate::game::event::{GameEvent, WaitingReason};
 use crate::game::rules;
 use crate::game::state::{GamePhase, GameState};
 use crate::player::{Player, PlayerChoice};
@@ -117,6 +117,16 @@ impl GameOrchestrator {
         match tokio::time::timeout(PLAYER_DECISION_TIMEOUT, future).await {
             Ok(result) => result,
             Err(_) => fallback,
+        }
+    }
+
+    /// Emit a `WaitingForHuman` event if the given player is human.
+    fn maybe_waiting_for_human(&mut self, player_id: PlayerId, reason: WaitingReason) {
+        if self.players[player_id].is_human() {
+            self.record_event(GameEvent::WaitingForHuman {
+                player: player_id,
+                reason,
+            });
         }
     }
 
@@ -295,8 +305,14 @@ impl GameOrchestrator {
     /// Run a single player's turn. Returns Some(winner) if the game ends.
     async fn run_turn(&mut self) -> Result<Option<PlayerId>, OrchestratorError> {
         let player_id = self.state.current_player();
+        let is_human = self.players[player_id].is_human();
         let name = self.player_names[player_id].clone();
         let turn_num = self.state.turn_number + 1;
+
+        self.record_event(GameEvent::TurnStarted {
+            player: player_id,
+            is_human,
+        });
 
         // Turn start narration.
         self.send_narration(format!("-- Turn {} -- {}'s turn --", turn_num, name));
@@ -383,6 +399,7 @@ impl GameOrchestrator {
             }
 
             self.send_narration(format!("{} is thinking...", name));
+            self.maybe_waiting_for_human(player_id, WaitingReason::YourTurn);
 
             let (choice_idx, reasoning) = self
                 .with_timeout(
@@ -567,6 +584,7 @@ impl GameOrchestrator {
                 "{} must discard {} cards...",
                 self.player_names[p], discard_count
             ));
+            self.maybe_waiting_for_human(p, WaitingReason::DiscardCards);
 
             let (cards, discard_reasoning) = self
                 .with_timeout(
@@ -599,6 +617,7 @@ impl GameOrchestrator {
             "{} is placing the robber...",
             self.player_names[roller]
         ));
+        self.maybe_waiting_for_human(roller, WaitingReason::PlaceRobber);
 
         let (h_idx, robber_reasoning) = self
             .with_timeout(
@@ -1046,6 +1065,7 @@ impl GameOrchestrator {
                 "{} is considering the trade...",
                 self.player_names[other_id]
             ));
+            self.maybe_waiting_for_human(other_id, WaitingReason::TradeResponse);
 
             let (response, resp_reasoning) = self
                 .with_timeout(
@@ -1258,6 +1278,16 @@ mod tests {
         assert_eq!(orch.max_turns, 500);
         assert!(orch.ui_tx.is_none());
         assert!(orch.events.is_empty());
+    }
+
+    #[test]
+    fn maybe_waiting_for_human_skips_non_human() {
+        let mut orch = make_orchestrator(3);
+        orch.maybe_waiting_for_human(0, WaitingReason::YourTurn);
+        assert!(
+            orch.events.is_empty(),
+            "Should not emit WaitingForHuman for RandomPlayer"
+        );
     }
 
     #[test]
@@ -1505,6 +1535,43 @@ mod tests {
             }
             _ => panic!("Expected BankTradeExecuted"),
         }
+    }
+
+    #[tokio::test]
+    async fn full_game_emits_turn_started_events() {
+        let mut orch = make_orchestrator(3);
+        orch.max_turns = 300;
+
+        let _ = orch.run().await;
+
+        let turn_started_count = orch
+            .events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::TurnStarted { .. }))
+            .count();
+        assert!(
+            turn_started_count > 0,
+            "Should have at least one TurnStarted event"
+        );
+
+        // Random players are not human, so all TurnStarted events should
+        // have is_human = false.
+        for event in &orch.events {
+            if let GameEvent::TurnStarted { is_human, .. } = event {
+                assert!(!is_human, "RandomPlayer should not be human");
+            }
+        }
+
+        // No WaitingForHuman events should fire for random (non-human) players.
+        let waiting_count = orch
+            .events
+            .iter()
+            .filter(|e| matches!(e, GameEvent::WaitingForHuman { .. }))
+            .count();
+        assert_eq!(
+            waiting_count, 0,
+            "No WaitingForHuman events for non-human players"
+        );
     }
 
     #[tokio::test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -21,6 +21,8 @@ use crate::game::event::GameEvent;
 /// Determine the event name string for a `GameEvent` variant (e.g. "DiceRolled").
 fn event_name(event: &GameEvent) -> &'static str {
     match event {
+        GameEvent::TurnStarted { .. } => "TurnStarted",
+        GameEvent::WaitingForHuman { .. } => "WaitingForHuman",
         GameEvent::InitialSettlementPlaced { .. } => "InitialSettlementPlaced",
         GameEvent::InitialRoadPlaced { .. } => "InitialRoadPlaced",
         GameEvent::DiceRolled { .. } => "DiceRolled",
@@ -120,6 +122,14 @@ mod tests {
     fn event_name_covers_all_variants() {
         // Verify every variant has a name by constructing one of each.
         let events = vec![
+            GameEvent::TurnStarted {
+                player: 0,
+                is_human: false,
+            },
+            GameEvent::WaitingForHuman {
+                player: 0,
+                reason: crate::game::event::WaitingReason::YourTurn,
+            },
             GameEvent::InitialSettlementPlaced {
                 player: 0,
                 vertex: dummy_vertex(),
@@ -198,13 +208,13 @@ mod tests {
         ];
 
         let names: Vec<&str> = events.iter().map(event_name).collect();
-        assert_eq!(names.len(), 18);
+        assert_eq!(names.len(), 20);
         // All names should be non-empty and unique.
         for name in &names {
             assert!(!name.is_empty());
         }
         let unique: std::collections::HashSet<&&str> = names.iter().collect();
-        assert_eq!(unique.len(), 18, "all event names should be unique");
+        assert_eq!(unique.len(), 20, "all event names should be unique");
     }
 
     #[test]

--- a/src/player/human.rs
+++ b/src/player/human.rs
@@ -67,6 +67,10 @@ impl Player for HumanPlayer {
         &self.name
     }
 
+    fn is_human(&self) -> bool {
+        true
+    }
+
     async fn choose_action(
         &self,
         state: &GameState,

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -224,6 +224,12 @@ pub trait Player: Send + Sync {
         player_names: &[String],
     ) -> (TradeResponse, String);
 
+    /// Whether this player is a human (as opposed to an AI/random player).
+    /// Used to emit lifecycle events for external status detection.
+    fn is_human(&self) -> bool {
+        false
+    }
+
     /// Provide extra game context (recent history, trade log) for the player's
     /// next decision. Default is a no-op; LLM players use this to enrich prompts.
     async fn set_game_context(&self, _context: &str) {}

--- a/src/player/tui_human.rs
+++ b/src/player/tui_human.rs
@@ -129,6 +129,10 @@ impl Player for TuiHumanPlayer {
         &self.name
     }
 
+    fn is_human(&self) -> bool {
+        true
+    }
+
     async fn choose_action(
         &self,
         _state: &GameState,


### PR DESCRIPTION
## Description

Adds two new lifecycle events (`TurnStarted`, `WaitingForHuman`) so external integrations can detect game status without inferring it from action events.

- `TurnStarted { player, is_human }` fires at the start of each player's turn
- `WaitingForHuman { player, reason }` fires when the game blocks on human input (reason: `your_turn`, `trade_response`, `discard_cards`, `place_robber`)
- Adds `is_human()` to the `Player` trait (default `false`, overridden by `HumanPlayer` and `TuiHumanPlayer`)
- Both events flow through the existing hook system, so external consumers can subscribe via `config.toml`

Fixes #149

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)