### PR TITLE
fix: show feedback when trade offer has no takers

### DIFF
--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -1122,6 +1122,8 @@ impl GameOrchestrator {
                     self.record_event(GameEvent::TradeWithdrawn { by: player_id });
                 }
             }
+        } else {
+            self.send_narration("No player could fulfill the trade.".into());
         }
 
         Ok(())

--- a/src/ui/input_tests.rs
+++ b/src/ui/input_tests.rs
@@ -661,6 +661,7 @@ fn trade_builder_resource_keys_add_to_give() {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 
@@ -682,6 +683,7 @@ fn trade_builder_give_capped_at_available() {
         side: TradeSide::Give,
         available: [1, 0, 0, 0, 0],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 
@@ -705,6 +707,7 @@ fn trade_builder_tab_switches_side() {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 
@@ -725,6 +728,7 @@ fn trade_builder_backspace_removes_last() {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 
@@ -747,6 +751,7 @@ fn trade_builder_enter_sends_trade_offer() {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 
@@ -770,6 +775,7 @@ fn trade_builder_enter_requires_both_sides() {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 
@@ -777,6 +783,43 @@ fn trade_builder_enter_requires_both_sides() {
 
     // Should not send anything since get side is empty.
     assert!(rx.try_recv().is_err());
+
+    // Should show a validation message.
+    if let Screen::Playing(ref ps) = app.screen {
+        if let InputMode::TradeBuilder { validation_msg, .. } = &ps.input_mode {
+            assert!(
+                validation_msg.is_some(),
+                "should show validation hint when Enter pressed with incomplete trade"
+            );
+        } else {
+            panic!("expected TradeBuilder mode");
+        }
+    }
+}
+
+#[test]
+fn trade_builder_validation_msg_clears_on_input() {
+    let (ps, _rx) = make_test_playing_state(InputMode::TradeBuilder {
+        give: [1, 0, 0, 0, 0],
+        get: [0; 5],
+        side: TradeSide::Give,
+        available: [3, 2, 1, 4, 2],
+        player_id: 0,
+        validation_msg: Some("Both GIVE and GET sides are required"),
+    });
+    let mut app = make_test_app(Screen::Playing(ps));
+
+    // Any resource key should clear the validation message.
+    handle_input(&mut app, KeyCode::Char('o'));
+
+    if let Screen::Playing(ref ps) = app.screen {
+        if let InputMode::TradeBuilder { validation_msg, .. } = &ps.input_mode {
+            assert!(
+                validation_msg.is_none(),
+                "validation message should clear on new input"
+            );
+        }
+    }
 }
 
 #[test]
@@ -787,6 +830,7 @@ fn trade_builder_esc_cancels() {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     let mut app = make_test_app(Screen::Playing(ps));
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -276,6 +276,7 @@ fn draw_context_bar(f: &mut Frame, ps: &PlayingState, area: Rect) {
             get,
             side,
             available,
+            validation_msg,
             ..
         } => {
             let give_str = format_resource_counts(give);
@@ -284,7 +285,7 @@ fn draw_context_bar(f: &mut Frame, ps: &PlayingState, area: Rect) {
                 TradeSide::Give => "\u{25b8}GIVE",
                 TradeSide::Get => "\u{25b8}GET",
             };
-            let lines = vec![
+            let mut lines = vec![
                 Line::from(vec![
                     Span::styled(" GIVE: ", Style::default().fg(if *side == TradeSide::Give { Color::Yellow } else { Color::White }).bold()),
                     Span::styled(&give_str, Style::default().fg(Color::White)),
@@ -303,6 +304,12 @@ fn draw_context_bar(f: &mut Frame, ps: &PlayingState, area: Rect) {
                     Style::default().fg(Color::DarkGray),
                 )),
             ];
+            if let Some(msg) = validation_msg {
+                lines.push(Line::from(Span::styled(
+                    format!(" {}", msg),
+                    Style::default().fg(Color::Red),
+                )));
+            }
             let para = Paragraph::new(lines);
             f.render_widget(para, inner);
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -175,6 +175,8 @@ pub enum InputMode {
         side: TradeSide,
         available: [u32; 5],
         player_id: usize,
+        /// Validation hint shown when user tries to send an incomplete trade.
+        validation_msg: Option<&'static str>,
     },
     /// Discarding cards with resource keys.
     Discard {
@@ -343,6 +345,7 @@ impl PlayingState {
                 side: TradeSide::Give,
                 available,
                 player_id: prompt.player_id,
+                validation_msg: None,
             },
             PromptKind::RespondToTrade { offer } => InputMode::TradeResponse { offer },
         };
@@ -1251,8 +1254,11 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                     side,
                     available,
                     player_id,
+                    validation_msg,
                 } => {
+                    // Clear validation message on any new input.
                     if let Some(idx) = resource_key_index(key) {
+                        *validation_msg = None;
                         match side {
                             TradeSide::Give => {
                                 if give[idx] < available[idx] {
@@ -1266,12 +1272,14 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                     }
                     match key {
                         KeyCode::Tab => {
+                            *validation_msg = None;
                             *side = match side {
                                 TradeSide::Give => TradeSide::Get,
                                 TradeSide::Get => TradeSide::Give,
                             };
                         }
                         KeyCode::Backspace => {
+                            *validation_msg = None;
                             let arr = match side {
                                 TradeSide::Give => give,
                                 TradeSide::Get => get,
@@ -1309,6 +1317,8 @@ fn handle_input(app: &mut App, key: KeyCode) -> Action {
                                 };
                                 ps.send_response(HumanResponse::Trade(Some(offer)));
                                 ps.input_mode = InputMode::Spectating;
+                            } else {
+                                *validation_msg = Some("Both GIVE and GET sides are required");
                             }
                         }
                         KeyCode::Esc => {

--- a/src/ui/testing.rs
+++ b/src/ui/testing.rs
@@ -185,6 +185,7 @@ pub fn playing_trade_builder_app() -> App {
         side: TradeSide::Give,
         available: [3, 2, 1, 4, 2],
         player_id: 0,
+        validation_msg: None,
     });
     make_test_app(Screen::Playing(ps))
 }


### PR DESCRIPTION
## Summary
- When a human player submits a trade and no AI player has the requested resources, the orchestrator now sends a "No player could fulfill the trade." narration instead of silently returning
- Added a red validation hint in the trade builder when Enter is pressed without filling both GIVE and GET sides, clearing on next keypress
- Added 2 regression tests (`trade_builder_enter_requires_both_sides` now checks validation_msg, new `trade_builder_validation_msg_clears_on_input`)

## Test plan
- [x] All 409 tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Manual: start a game, propose a trade requesting resources no AI has -- verify "No player could fulfill the trade." appears in chat
- [ ] Manual: open trade builder, fill only GIVE side, press Enter -- verify red validation hint appears
- [ ] Manual: after seeing validation hint, press any resource key -- verify hint disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)