### PR TITLE
fix: add per-chunk idle timeout to SSE streaming reader

### DIFF
--- a/src/player/anthropic_client.rs
+++ b/src/player/anthropic_client.rs
@@ -504,11 +504,27 @@ impl AnthropicClient {
 
         let mut processor = SseProcessor::new(reasoning_tx);
         let mut resp = resp;
-        while let Some(chunk) = resp.chunk().await.map_err(|e| ApiError {
-            status: None,
-            message: format!("Stream read error: {}", e),
-        })? {
-            processor.feed(&String::from_utf8_lossy(&chunk));
+        let chunk_timeout = std::time::Duration::from_secs(60);
+        loop {
+            let chunk_result = tokio::time::timeout(chunk_timeout, resp.chunk()).await;
+            match chunk_result {
+                Ok(Ok(Some(chunk))) => {
+                    processor.feed(&String::from_utf8_lossy(&chunk));
+                }
+                Ok(Ok(None)) => break,
+                Ok(Err(e)) => {
+                    return Err(ApiError {
+                        status: None,
+                        message: format!("Stream read error: {}", e),
+                    });
+                }
+                Err(_) => {
+                    return Err(ApiError {
+                        status: None,
+                        message: "Stream idle timeout: no data received for 60s".to_string(),
+                    });
+                }
+            }
         }
 
         let response = processor.finish();


### PR DESCRIPTION
## Summary
- Adds a 60-second per-chunk idle timeout to the SSE streaming reader in `anthropic_client.rs`
- When the llamafile server stalls under KV cache memory pressure (observed with Bonsai 8B after ~9 turns), the old code waited the full 300s reqwest timeout before recovering
- Now hung requests fail fast with a clear "Stream idle timeout" error, triggering the existing retry/fallback logic in `llm_player.rs`

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 408 tests pass
- [ ] Manual test: run a 4-player game with Bonsai 8B llamafile and verify the game recovers within ~60s if the server stalls, instead of hanging for 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)