### PR TITLE
fix: detect game engine death and fix robber hex filtering

### DIFF
--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::game::actions::{Action, DevCard, DevCardAction, PlayerId, TradeResponse};
-use crate::game::board::{board_hex_coords, Resource};
+use crate::game::board::Resource;
 use crate::game::dice;
 use crate::game::event::{GameEvent, WaitingReason};
 use crate::game::rules;
@@ -196,7 +196,16 @@ impl GameOrchestrator {
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
 
-            if let Some(winner) = self.run_turn().await? {
+            let turn_result = self.run_turn().await;
+            if let Err(ref e) = turn_result {
+                log::error!(
+                    "Turn {} error (player {}): {}",
+                    self.state.turn_number,
+                    self.state.current_player(),
+                    e
+                );
+            }
+            if let Some(winner) = turn_result? {
                 let vp = self.state.victory_points(winner);
                 let msg = format!("{} wins with {} VP!", self.player_names[winner], vp);
                 self.record_event(GameEvent::GameWon {
@@ -618,10 +627,7 @@ impl GameOrchestrator {
             current_player: roller,
         };
 
-        let legal_hexes: Vec<_> = board_hex_coords()
-            .into_iter()
-            .filter(|&h| h != self.state.robber_hex)
-            .collect();
+        let legal_hexes = rules::legal_robber_hexes(&self.state, roller);
 
         self.send_narration(format!(
             "{} is placing the robber...",
@@ -762,10 +768,7 @@ impl GameOrchestrator {
     /// Handle playing a Knight dev card (multi-step: remove card, move robber, steal).
     async fn handle_knight(&mut self, player_id: PlayerId) -> Result<(), OrchestratorError> {
         // Legal hexes for robber.
-        let legal_hexes: Vec<_> = board_hex_coords()
-            .into_iter()
-            .filter(|&h| h != self.state.robber_hex)
-            .collect();
+        let legal_hexes = rules::legal_robber_hexes(&self.state, player_id);
 
         let (h_idx, h_reasoning) = self
             .with_timeout(

--- a/src/game/rules.rs
+++ b/src/game/rules.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::game::actions::{Action, DevCard, DevCardAction, PlayerId};
 use crate::game::board::{
-    adjacent_edges, adjacent_vertices, edge_neighbors, edge_vertices, vertex_neighbors, Board,
-    EdgeCoord, HexCoord, PortType, Resource, VertexCoord,
+    adjacent_edges, adjacent_vertices, board_hex_coords, edge_neighbors, edge_vertices,
+    vertex_neighbors, Board, EdgeCoord, HexCoord, PortType, Resource, VertexCoord,
 };
 use crate::game::dice::{total_in_circulation, BANK_SUPPLY_PER_RESOURCE};
 use crate::game::state::{Building, GamePhase, GameState, VP_TO_WIN};
@@ -944,6 +944,17 @@ fn friendly_robber_blocks(state: &GameState, hex: HexCoord, player: PlayerId) ->
         }
     }
     found_any
+}
+
+/// Return the hexes where `player` may legally place the robber.
+///
+/// Excludes the current robber position and any hex blocked by the
+/// friendly robber rule.
+pub fn legal_robber_hexes(state: &GameState, player: PlayerId) -> Vec<HexCoord> {
+    board_hex_coords()
+        .into_iter()
+        .filter(|&h| h != state.robber_hex && !friendly_robber_blocks(state, h, player))
+        .collect()
 }
 
 /// Move the robber to a new hex.
@@ -2177,6 +2188,30 @@ mod tests {
         )
         .unwrap();
         assert_eq!(state.robber_hex, target_hex);
+    }
+
+    #[test]
+    fn legal_robber_hexes_excludes_current_position() {
+        let state = make_state(3);
+        let hexes = legal_robber_hexes(&state, 0);
+        assert!(!hexes.contains(&state.robber_hex));
+    }
+
+    #[test]
+    fn legal_robber_hexes_excludes_friendly_robber_blocked() {
+        let mut state = make_friendly_robber_state(3);
+        // Place a low-VP opponent settlement adjacent to hex (1,0).
+        let target_hex = HexCoord::new(1, 0);
+        let vertex = target_hex.vertices()[0];
+        state.buildings.insert(vertex, Building::Settlement(1));
+        assert_eq!(state.victory_points(1), 1);
+
+        let hexes = legal_robber_hexes(&state, 0);
+        // Target hex should be excluded because player 1 has <= 2 VP.
+        assert!(
+            !hexes.contains(&target_hex),
+            "legal_robber_hexes should exclude hex blocked by friendly robber"
+        );
     }
 
     // -- Legal actions --

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -783,8 +783,23 @@ async fn run_event_loop(
 
         // Drain game events for Playing screen.
         if let Screen::Playing(ref mut ps) = app.screen {
-            while let Ok(ui_event) = ps.rx.try_recv() {
-                ps.handle_game_event(ui_event);
+            loop {
+                match ps.rx.try_recv() {
+                    Ok(ui_event) => ps.handle_game_event(ui_event),
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        if !ps.game_over {
+                            ps.game_over = true;
+                            ps.push_message(
+                                "Game engine stopped unexpectedly. \
+                                 Check ~/.settl/debug.log for details."
+                                    .into(),
+                            );
+                            log::error!("Game engine task disconnected unexpectedly");
+                        }
+                        break;
+                    }
+                }
             }
 
             // Check for incoming human prompts.
@@ -1730,7 +1745,9 @@ fn launch_game(
         orchestrator.player_configs = save_configs;
         orchestrator.model_name = model_name;
 
-        orchestrator.run().await
+        if let Err(e) = orchestrator.run().await {
+            log::error!("Game engine error: {}", e);
+        }
     });
 
     let human_player_index = active_players
@@ -1866,7 +1883,9 @@ fn resume_game(
         orchestrator.model_name = model_name;
         orchestrator.events = events;
 
-        orchestrator.run().await
+        if let Err(e) = orchestrator.run().await {
+            log::error!("Game engine error: {}", e);
+        }
     });
 
     let human_player_index = save.player_configs.iter().position(|p| p.is_human);


### PR DESCRIPTION
## Summary
- **TUI now detects when the game engine dies** instead of silently hanging. The event drain loop distinguishes `Empty` (normal) from `Disconnected` (task died) and shows an error message pointing to `~/.settl/debug.log`.
- **Robber hex filtering respects the friendly robber rule.** Added `legal_robber_hexes()` in rules.rs that filters out blocked hexes before showing them to AI players. Both `handle_seven()` and `handle_knight()` use it.
- **Error logging at key boundaries** -- orchestrator logs turn errors before propagating, and both game spawn sites (launch + resume) log errors before the task ends.

## Root cause
The orchestrator runs in a `tokio::spawn` whose `JoinHandle` was dropped. Any `OrchestratorError` (e.g. from `?` operators in `handle_seven`) silently killed the task. The TUI used `while let Ok(...) = try_recv()` which treats both "no messages" and "sender gone" the same way, so the game appeared frozen.

The likely trigger: with friendly robber enabled, the legal hex list didn't filter for it, so the AI could pick a hex that `apply_move_robber` rejects.

## Test plan
- [x] `cargo test` -- all 411 tests pass
- [x] `cargo clippy` and `cargo fmt` clean
- [x] New tests: `legal_robber_hexes_excludes_current_position`, `legal_robber_hexes_excludes_friendly_robber_blocked`
- [ ] Manual: play a game with friendly robber on -- verify AI never picks a blocked hex
- [ ] Manual: kill llamafile mid-game -- verify TUI shows error instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)