### PR TITLE
fix: prevent AI from re-proposing identical trades rejected in same turn

### DIFF
--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -41,6 +41,9 @@ impl std::fmt::Display for OrchestratorError {
 
 impl std::error::Error for OrchestratorError {}
 
+/// A (offering, requesting) resource pair identifying a trade offer for dedup.
+type TradeOfferKey = (Vec<(Resource, u32)>, Vec<(Resource, u32)>);
+
 /// Drives a complete game from setup through victory.
 pub struct GameOrchestrator {
     pub state: GameState,
@@ -59,6 +62,8 @@ pub struct GameOrchestrator {
     pub player_configs: Vec<crate::game::save::SavedPlayerConfig>,
     /// Name of the AI model in use (for auto-save, matches Config.models entry).
     pub model_name: String,
+    /// Trade offers rejected this turn, to prevent duplicate proposals.
+    turn_rejected_offers: Vec<TradeOfferKey>,
 }
 
 impl GameOrchestrator {
@@ -74,6 +79,7 @@ impl GameOrchestrator {
             ui_tx: None,
             player_configs: Vec::new(),
             model_name: String::new(),
+            turn_rejected_offers: Vec::new(),
         }
     }
 
@@ -354,6 +360,7 @@ impl GameOrchestrator {
 
     /// Run a single player's turn. Returns Some(winner) if the game ends.
     async fn run_turn(&mut self) -> Result<Option<PlayerId>, OrchestratorError> {
+        self.turn_rejected_offers.clear();
         let player_id = self.state.current_player();
         let is_human = self.players[player_id].is_human();
         let name = self.player_names[player_id].clone();
@@ -1140,6 +1147,18 @@ impl GameOrchestrator {
             )));
         }
 
+        // Skip duplicate trade offers that were already rejected this turn.
+        let offer_key = (offer.offering.clone(), offer.requesting.clone());
+        if self.turn_rejected_offers.contains(&offer_key) {
+            log::info!(
+                "{} re-proposed a trade that was already rejected this turn, skipping",
+                self.player_names[player_id]
+            );
+            return Err(OrchestratorError::RuleViolation(
+                "Duplicate trade already rejected this turn".into(),
+            ));
+        }
+
         let offering: String = offer
             .offering
             .iter()
@@ -1274,6 +1293,7 @@ impl GameOrchestrator {
                 None,
             );
             self.send_narration("No player could fulfill the trade.".into());
+            self.turn_rejected_offers.push(offer_key);
         }
 
         Ok(())

--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -1189,25 +1189,22 @@ impl GameOrchestrator {
 
         // Step 2: Find eligible responders and collect responses.
         let eligible = trading::negotiation::eligible_responders(&self.state, &offer);
+
+        // Short-circuit: if nobody has the requested resources, fail immediately
+        // with a clear message instead of silently rejecting on everyone's behalf.
+        if eligible.is_empty() {
+            self.send_ui(
+                format!("Trade failed: no one has [{}] to trade", requesting),
+                None,
+            );
+            self.send_narration("No player has the requested resources.".into());
+            self.turn_rejected_offers.push(offer_key);
+            return Ok(());
+        }
+
         let mut accepted_by: Option<PlayerId> = None;
 
-        for other_id in 0..self.state.num_players {
-            if other_id == player_id {
-                continue;
-            }
-
-            if !eligible.contains(&other_id) {
-                self.send_narration(format!(
-                    "{} can't trade (insufficient resources)",
-                    self.player_names[other_id]
-                ));
-                self.record_event(GameEvent::TradeRejected {
-                    by: other_id,
-                    reasoning: "Insufficient resources".into(),
-                });
-                continue;
-            }
-
+        for &other_id in &eligible {
             self.send_narration(format!(
                 "{} is considering the trade...",
                 self.player_names[other_id]
@@ -1292,7 +1289,7 @@ impl GameOrchestrator {
                 ),
                 None,
             );
-            self.send_narration("No player could fulfill the trade.".into());
+            self.send_narration("All eligible players declined the trade.".into());
             self.turn_rejected_offers.push(offer_key);
         }
 


### PR DESCRIPTION
## Summary
- AI players could propose the same trade multiple times per turn, causing confusing log output where "Trade failed: no one accepted [1 Wood] for [1 Ore]" appeared immediately before "Trade: Leif gave [1 Wood] to Marco for [1 Ore]" -- the LLM responder inconsistently rejected then accepted the same offer
- Track rejected trade offers per turn by their (offering, requesting) resource key in the orchestrator; duplicate proposals are immediately rejected as a RuleViolation without polling other players, so the AI picks a different action instead

## Test plan
- [x] `cargo test` -- all 436 tests pass
- [x] `cargo clippy` -- clean
- [x] `cargo fmt` -- clean
- [ ] Manual testing: run `cargo run -- --headless --players 2` and verify no duplicate trade proposals appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)