### PR TITLE
fix: sync UI state after resource distribution, discards, and robber placement

### DIFF
--- a/src/game/orchestrator.rs
+++ b/src/game/orchestrator.rs
@@ -457,6 +457,10 @@ impl GameOrchestrator {
             has_rolled: true,
         };
 
+        // Sync the UI with post-roll state (distributed resources or robber move)
+        // before the action loop, so the resource bar matches reality.
+        self.send_ui(String::new(), None);
+
         // Step 3: Action loop -- player takes actions until EndTurn.
         let max_actions_per_turn = 15;
         let max_trades_per_turn = 3;
@@ -695,6 +699,10 @@ impl GameOrchestrator {
                 player: p,
                 cards: cards.clone(),
             });
+            self.send_ui(
+                format!("{} discarded {} cards", self.player_names[p], cards.len()),
+                None,
+            );
         }
 
         // Step 2: Move robber.
@@ -776,6 +784,11 @@ impl GameOrchestrator {
                 stole_from: None,
             });
         }
+
+        self.send_ui(
+            format!("{} placed the robber", self.player_names[roller]),
+            None,
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- The orchestrator called `send_ui()` before state-mutating operations (dice roll, resource distribution, discards, robber placement) but not after, so the TUI resource bar showed stale counts while the bank trade dialog showed correct ones
- Added three `send_ui()` calls: after resource distribution + phase transition (before the action loop), after each discard in `handle_seven`, and after robber placement/steal resolution
- Single file change, 13 lines added to `src/game/orchestrator.rs`

## Test plan
- [x] `cargo test` -- 436 passed, 0 failed
- [x] `cargo clippy` -- clean
- [x] `cargo fmt --check` -- clean
- [ ] Manual: play a game, roll non-7, verify resource bar matches bank trade dialog
- [ ] Manual: roll a 7, verify robber hex updates immediately after placement
- [ ] Manual: roll a 7 with >7 cards, verify resource bar updates after discard

🤖 Generated with [Claude Code](https://claude.com/claude-code)